### PR TITLE
chore(renovate): set rebaseWhen: "conflicted"

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -7,6 +7,7 @@
     prHourlyLimit: 0,
     prConcurrentLimit: 0,
     branchConcurrentLimit: 0,
+    rebaseWhen: "conflicted",
     regexManagers: [
         {
             fileMatch: "package\\.yaml$",


### PR DESCRIPTION
Package definitions are entirely independent of one another, no need to
ensure branches are up to date.
