### PR TITLE
chore(workflows): dont run package tests on push

### DIFF
--- a/.github/workflows/package-tests.yaml
+++ b/.github/workflows/package-tests.yaml
@@ -2,9 +2,6 @@
 name: Package tests
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
This doesn't really serve any purpose, running on PRs is enough.
