### PR TITLE
chore(renovate): update commitMessage

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -2,7 +2,7 @@
     automerge: true,
     platformAutomerge: true,
     automergeType: "pr",
-    commitMessage: "bump({{depName}}): update to {{prettyNewVersion}}",
+    commitMessage: "bump({{decodeURIComponent depName}}): update to {{prettyNewVersion}}",
     separateMajorMinor: false,
     prHourlyLimit: 0,
     prConcurrentLimit: 0,


### PR DESCRIPTION
Reverts mason-org/mason-registry#160

renovate seems to be running updated version where this helper is included now