### PR TITLE
feat: add ability to override source definition for historic version ranges

### DIFF
--- a/packages/zk/package.yaml
+++ b/packages/zk/package.yaml
@@ -21,5 +21,11 @@ source:
     - target: darwin_arm64
       file: zk-{{version}}-macos-arm64.zip
 
+  version_overrides:
+    - constraint: semver:<=0.11.1
+      asset:
+        - target: darwin_x64
+          file: zk-{{version}}-macos-x86_64.zip
+
 bin:
   zk: zk

--- a/schemas/components/sources/github/release.json
+++ b/schemas/components/sources/github/release.json
@@ -4,52 +4,41 @@
     "type": "object",
     "$defs": {
         "Asset": {
-            "type": "object",
-            "required": ["target", "file"],
-            "additionalProperties": true,
-            "properties": {
-                "target": {
-                    "oneOf": [
-                        {
-                            "type": "array",
-                            "items": {
-                                "$ref": "/mason-org/mason-registry/schemas/enums/platform"
-                            }
-                        },
-                        {
-                            "$ref": "/mason-org/mason-registry/schemas/enums/platform"
-                        }
-                    ]
-                },
-                "file": {
-                    "oneOf": [
-                        {
-                            "type": "array",
-                            "items": {
-                                "type": "string"
-                            }
-                        },
-                        {
-                            "type": "string"
-                        }
-                    ]
-                }
-            }
-        }
-    },
-    "additionalProperties": false,
-    "required": ["id", "asset"],
-    "properties": {
-        "id": {
-            "type": "string",
-            "pattern": "^pkg:github/.+@.+"
-        },
-        "asset": {
             "oneOf": [
                 {
                     "type": "array",
                     "items": {
-                        "$ref": "#/$defs/Asset"
+                        "type": "object",
+                        "required": ["target", "file"],
+                        "additionalProperties": true,
+                        "properties": {
+                            "target": {
+                                "oneOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "$ref": "/mason-org/mason-registry/schemas/enums/platform"
+                                        }
+                                    },
+                                    {
+                                        "$ref": "/mason-org/mason-registry/schemas/enums/platform"
+                                    }
+                                ]
+                            },
+                            "file": {
+                                "oneOf": [
+                                    {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        }
+                                    },
+                                    {
+                                        "type": "string"
+                                    }
+                                ]
+                            }
+                        }
                     }
                 },
                 {
@@ -61,6 +50,32 @@
                     }
                 }
             ]
+        }
+    },
+    "additionalProperties": false,
+    "required": ["id", "asset"],
+    "properties": {
+        "id": {
+            "type": "string",
+            "pattern": "^pkg:github/.+@.+"
+        },
+        "asset": {
+            "$ref": "#/$defs/Asset"
+        },
+        "version_overrides": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "constraint": {
+                        "type": "string",
+                        "pattern": "^semver:(<=)?v?\\d+\\.\\d+\\.\\d+"
+                    },
+                    "asset": {
+                        "$ref": "#/$defs/Asset"
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
This mechanism applies to all sources, not just GitHub releases, so the JSON schema is not entirely correct (it only accepts `version_overrides` for GitHub release sources), but I decided I don't care.