### PR TITLE
feat: add markdown-toc

### DIFF
--- a/packages/markdown-toc/package.yaml
+++ b/packages/markdown-toc/package.yaml
@@ -1,0 +1,16 @@
+---
+name: markdown-toc
+description: API and CLI for generating a markdown TOC (table of contents) for a README or any markdown files.
+homepage: https://github.com/jonschlinkert/markdown-toc
+licenses:
+  - MIT
+languages:
+  - Markdown
+categories:
+  - Formatter
+
+source:
+  id: pkg:npm/markdown-toc@1.2.0
+
+bin:
+  markdown-toc: npm:markdown-toc


### PR DESCRIPTION
`null-ls.nvim` contains `markdown_toc` BUILTIN,
while `mason.nvim` does not provide a source.

Ref: https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/doc/BUILTINS.md#markdown_toc