### PR TITLE
feat(js-debug-adapter): add dap server alias

### DIFF
--- a/packages/js-debug-adapter/package.yaml
+++ b/packages/js-debug-adapter/package.yaml
@@ -12,13 +12,8 @@ categories:
 
 source:
   id: pkg:github/microsoft/vscode-js-debug@v1.77.0
-  build:
-    run: |
-      npm install --ignore-scripts
-      npm run compile
-      npm exec -- gulp vsDebugServerBundle
-      npm install --production --ignore-scripts
+  asset:
+    file: js-debug-dap-{{version}}.tar.gz
 
 bin:
-  js-debug-adapter: node:dist/src/vsDebugServer.js
-  js-debug-adapter-dap: node:dist/src/dapDebugServer.js
+  js-debug-adapter: node:js-debug/src/dapDebugServer.js

--- a/packages/js-debug-adapter/package.yaml
+++ b/packages/js-debug-adapter/package.yaml
@@ -21,3 +21,4 @@ source:
 
 bin:
   js-debug-adapter: node:dist/src/vsDebugServer.js
+  js-debug-adapter-dap: node:dist/src/dapDebugServer.js


### PR DESCRIPTION
See https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#vscode-js-debug which uses the dapServer instead of the vsDebugServer