### PR TITLE
fix(renovate): set empty currentValue if updating git-refs digests

### DIFF
--- a/packages/groovy-language-server/package.yaml
+++ b/packages/groovy-language-server/package.yaml
@@ -11,7 +11,7 @@ categories:
 
 source:
   # renovate:datasource=git-refs
-  id: pkg:github/GroovyLanguageServer/groovy-language-server@6439fc5b98b3b7187650c60ed561f7f18da3f62c # renovate:digest
+  id: pkg:github/GroovyLanguageServer/groovy-language-server@6439fc5b98b3b7187650c60ed561f7f18da3f62c
   build:
     run: ./gradlew --no-daemon build
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -14,14 +14,15 @@
             matchStringsStrategy: "combination",
             matchStrings: [
                 "pkg:github\\/(?<packageName>.+)@(?<currentValue>[^\\s\\?#]+)",
-                "pkg:github\\/(?<packageName>.+)@(?<currentDigest>[^\\s\\?#]+).*renovate:digest",
                 "\nname: (?<depName>.+)",
+                "# renovate:datasource=git-refs.*pkg:github\\/(?<packageName>.+)@(?<currentDigest>[^\\s\\?#]+)",
                 "# renovate:.*versioning=(?<versioning>[^,\n]+)",
                 "# renovate:.*datasource=(?<datasource>[^,\n]+)",
             ],
             datasourceTemplate: "{{#if datasource}}{{{datasource}}}{{else}}github-releases{{/if}}",
             versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
             packageNameTemplate: "{{#if (containsString datasource 'git-refs')}}https://github.com/{{{packageName}}}{{else}}{{{packageName}}}{{/if}}",
+            currentValueTemplate: "{{#if (containsString datasource 'git-refs')}}{{else}}{{currentValue}}{{/if}}",
         },
         {
             fileMatch: "package\\.yaml$",


### PR DESCRIPTION
This is a headache to debug (I'm reviewing the source code of renovate to figure this out step by step).
