### PR TITLE
feat: add helm-ls

### DIFF
--- a/packages/helm-ls/package.yaml
+++ b/packages/helm-ls/package.yaml
@@ -1,6 +1,6 @@
 ---
-name: helm_ls
-description: A language server that offers Helm support in early development- programmed in Go.
+name: helm-ls
+description: A language server that offers Helm support in early development - programmed in Go.
 homepage: https://github.com/mrjosh/helm-ls
 licenses:
   - MIT
@@ -10,22 +10,18 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/mrjosh/helm-ls@latest
+  id: pkg:github/mrjosh/helm-ls@v0.0.3
   asset:
     - target: darwin_x64
       file: helm_ls_darwin_amd64
-      bin: helm_ls_darwin_amd64
     - target: darwin_arm64
       file: helm_ls_darwin_arm64
-      bin: helm_ls_darwin_arm64
     - target: win_x64
       file: helm_ls_windows_amd64
-      bin: helm_ls_windows_amd64
-    - target: linux_x64
+    - target: linux_x64_gnu
       file: helm_ls_linux_amd64
-      bin: helm_ls_linux_amd64
     - target: linux_arm
       file: helm_ls_linux_arm
-      bin: helm_ls_linux_arm
+
 bin:
-  helm_ls: "{{source.asset.bin}}"
+  helm_ls: "{{source.asset.file}}"

--- a/packages/helm-ls/package.yaml
+++ b/packages/helm-ls/package.yaml
@@ -17,7 +17,7 @@ source:
     - target: darwin_arm64
       file: helm_ls_darwin_arm64
     - target: win_x64
-      file: helm_ls_windows_amd64
+      file: helm_ls_windows_amd64:helm_ls_windows_amd64.exe
     - target: linux_x64_gnu
       file: helm_ls_linux_amd64
     - target: linux_arm

--- a/packages/helm_ls/package.yaml
+++ b/packages/helm_ls/package.yaml
@@ -28,4 +28,4 @@ source:
       file: helm_ls_linux_arm
       bin: helm_ls_linux_arm
 bin:
-  helm_ls: "{{source.asset.file}}"
+  helm_ls: "{{source.asset.bin}}"

--- a/packages/helm_ls/package.yaml
+++ b/packages/helm_ls/package.yaml
@@ -17,7 +17,7 @@ source:
       bin: helm_ls_darwin_amd64
     - target: darwin_arm64
       file: helm_ls_darwin_arm64
-      bin: helm_ls_darwin_amd64
+      bin: helm_ls_darwin_arm64
     - target: win_x64
       file: helm_ls_windows_amd64
       bin: helm_ls_windows_amd64

--- a/packages/helm_ls/package.yaml
+++ b/packages/helm_ls/package.yaml
@@ -1,0 +1,31 @@
+---
+name: helm_ls
+description: A language server that offers Helm support in early development- programmed in Go.
+homepage: https://github.com/mrjosh/helm-ls
+licenses:
+  - MIT
+languages:
+  - Helm
+categories:
+  - LSP
+
+source:
+  id: pkg:github/mrjosh/helm-ls@latest
+  asset:
+    - target: darwin_x64
+      file: helm_ls_darwin_amd64
+      bin: helm_ls_darwin_amd64
+    - target: darwin_arm64
+      file: helm_ls_darwin_arm64
+      bin: helm_ls_darwin_amd64
+    - target: win_x64
+      file: helm_ls_windows_amd64
+      bin: helm_ls_windows_amd64
+    - target: linux_x64
+      file: helm_ls_linux_amd64
+      bin: helm_ls_linux_amd64
+    - target: linux_arm
+      file: helm_ls_linux_arm
+      bin: helm_ls_linux_arm
+bin:
+  helm_ls: "{{source.asset.file}}"

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -66,7 +66,6 @@
         "Haskell",
         "Haxe",
         "Helm",
-        "Helm",
         "Hoon",
         "JSON",
         "JSX",

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -65,6 +65,7 @@
         "Handlebars",
         "Haskell",
         "Haxe",
+        "Helm",
         "Hoon",
         "JSON",
         "JSX",

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -66,6 +66,7 @@
         "Haskell",
         "Haxe",
         "Helm",
+        "Helm",
         "Hoon",
         "JSON",
         "JSX",


### PR DESCRIPTION
i found an early state project, that provide a Language server for Helm file.
even if it's in early dev, it work really good.
would be good to have this LSP in Mason.

especially for DevOps ppl.