### PR TITLE
feat: add prettier-eslint

### DIFF
--- a/packages/prettier-eslint/package.yaml
+++ b/packages/prettier-eslint/package.yaml
@@ -1,0 +1,29 @@
+---
+name: prettier-eslint
+description: Prettier followed by eslint --fix
+homepage: http://github.com/prettier/prettier-eslint
+licenses:
+  - MIT
+languages:
+  - Angular
+  - CSS
+  - Flow
+  - GraphQL
+  - HTML
+  - JSON
+  - JSX
+  - JavaScript
+  - LESS
+  - Markdown
+  - SCSS
+  - TypeScript
+  - Vue
+  - YAML
+categories:
+  - Formatter
+
+source:
+  id: pkg:npm/prettier-eslint@15.0.1
+
+bin:
+  prettier-eslint: npm:prettier-eslint


### PR DESCRIPTION
Sorry I couldn't find any etiquette for the PR template but I'm trying to add [prettier-eslint](https://github.com/prettier/prettier-eslint)
I'm not quite sure how to test this locally... i tried adding my fork to the registries list but i get an error that it failed
```
Registry installation failed with the following error:
    GitHubRegistrySource(repo=jnhooper/mason-registry) failed to install: Failed to download registry archive.```