### PR TITLE
feat: add tfsec

### DIFF
--- a/packages/tfsec/package.yaml
+++ b/packages/tfsec/package.yaml
@@ -1,0 +1,16 @@
+---
+name: tfsec
+description: Security scanner for your Terraform code
+homepage: https://github.com/aquasecurity/tfsec
+licenses:
+  - MIT
+languages:
+  - Terraform
+categories:
+  - Linter
+
+source:
+  id: pkg:golang/github.com/aquasecurity/tfsec@v1.28.1#cmd/tfsec
+
+bin:
+  tfsec: golang:tfsec


### PR DESCRIPTION
This adds `tfsec` to the mason registry, used by `null-ls`.

I'm unsure how to test this locally so beware. :)