### PR TITLE
feat: Add debug-adapter-haskell

### DIFF
--- a/packages/haskell-debug-adapter/package.yaml
+++ b/packages/haskell-debug-adapter/package.yaml
@@ -25,7 +25,7 @@ source:
 
     - target: win
       run: |
-        stack install haskell-dap ghci-dap haskell-debug-adapter-"$env:VERSION" --local-bin-path=($pwd).path
+        stack install haskell-dap ghci-dap haskell-debug-adapter-($env:VERSION) --local-bin-path=($pwd).path
       staged: false
       env:
         VERSION: "{{version}}"

--- a/packages/haskell-debug-adapter/package.yaml
+++ b/packages/haskell-debug-adapter/package.yaml
@@ -15,29 +15,24 @@ source:
   build:
     - target: unix
       run: |
-        ghcup install stack latest -i "$PWD"
-        ./stack install haskell-dap ghci-dap haskell-debug-adapter-"$VERSION" --local-bin-path="$PWD"
+        stack install haskell-dap ghci-dap haskell-debug-adapter-"$VERSION" --local-bin-path="$PWD"
       staged: false
       env:
         VERSION: "{{version}}"
       bin:
-        stack: stack
         ghci-dap: ghci-dap
         haskell-debug-adapter: haskell-debug-adapter
 
     - target: win
       run: |
-        ghcup install stack latest -i ($pwd).path
-        stack.exe install haskell-dap ghci-dap haskell-debug-adapter-"$env:VERSION" --local-bin-path=($pwd).path
+        stack install haskell-dap ghci-dap haskell-debug-adapter-"$env:VERSION" --local-bin-path=($pwd).path
       staged: false
       env:
         VERSION: "{{version}}"
       bin:
-        stack: stack.exe
         ghci-dap: ghci-dap.exe
         haskell-debug-adapter: haskell-debug-adapter.exe
 
 bin:
-  stack: "{{source.build.bin.stack}}"
   ghci-dap: "{{source.build.bin.ghci-dap}}"
   haskell-debug-adapter: "{{source.build.bin.haskell-debug-adapter}}"

--- a/packages/haskell-debug-adapter/package.yaml
+++ b/packages/haskell-debug-adapter/package.yaml
@@ -25,7 +25,7 @@ source:
 
     - target: win
       run: |
-        stack install haskell-dap ghci-dap haskell-debug-adapter-$env:VERSION --local-bin-path=($pwd).path
+        stack install haskell-dap ghci-dap haskell-debug-adapter-$env:VERSION --local-bin-path="$pwd"
       staged: false
       env:
         VERSION: "{{version}}"

--- a/packages/haskell-debug-adapter/package.yaml
+++ b/packages/haskell-debug-adapter/package.yaml
@@ -1,0 +1,40 @@
+---
+name: haskell-debug-adapter
+description: A debug adapter for Haskell debugging system.
+homepage: https://github.com/phoityne/haskell-debug-adapter
+licenses:
+  - BSD-3-Clause
+languages:
+  - Haskell
+categories:
+  - DAP
+
+source:
+  # renovate:datasource=github-releases
+  id: pkg:generic/phoityne/haskell-debug-adapter@0.0.39.0
+  build:
+    - target: unix
+      run: |
+        ghcup install stack latest -i "$PWD"
+        ./stack install haskell-dap ghci-dap haskell-debug-adapter-"$VERSION" --local-bin-path="$PWD/bin"
+      staged: false
+      env:
+        VERSION: "{{version}}"
+      bin:
+        ghci-dap: bin/ghci-dap
+        haskell-debug-adapter: bin/haskell-debug-adapter
+
+    - target: win
+      run: |
+        ghcup install stack latest -i ($pwd).path
+        stack.exe install haskell-dap ghci-dap haskell-debug-adapter-"$env:VERSION" --local-bin-path=($pwd).path
+      staged: false
+      env:
+        VERSION: "{{version}}"
+      bin:
+        ghci-dap: ghci-dap.exe
+        haskell-debug-adapter: haskell-debug-adapter.exe
+
+bin:
+  ghci-dap: "{{source.build.bin.ghci-dap}}"
+  haskell-debug-adapter: "{{source.build.bin.haskell-debug-adapter}}"

--- a/packages/haskell-debug-adapter/package.yaml
+++ b/packages/haskell-debug-adapter/package.yaml
@@ -25,7 +25,7 @@ source:
 
     - target: win
       run: |
-        stack install haskell-dap ghci-dap haskell-debug-adapter-($env:VERSION) --local-bin-path=($pwd).path
+        stack install haskell-dap ghci-dap haskell-debug-adapter-$env:VERSION --local-bin-path=($pwd).path
       staged: false
       env:
         VERSION: "{{version}}"

--- a/packages/haskell-debug-adapter/package.yaml
+++ b/packages/haskell-debug-adapter/package.yaml
@@ -16,14 +16,14 @@ source:
     - target: unix
       run: |
         ghcup install stack latest -i "$PWD"
-        ./stack install haskell-dap ghci-dap haskell-debug-adapter-"$VERSION" --local-bin-path="$PWD/bin"
+        ./stack install haskell-dap ghci-dap haskell-debug-adapter-"$VERSION" --local-bin-path="$PWD"
       staged: false
       env:
         VERSION: "{{version}}"
       bin:
         stack: stack
-        ghci-dap: bin/ghci-dap
-        haskell-debug-adapter: bin/haskell-debug-adapter
+        ghci-dap: ghci-dap
+        haskell-debug-adapter: haskell-debug-adapter
 
     - target: win
       run: |

--- a/packages/haskell-debug-adapter/package.yaml
+++ b/packages/haskell-debug-adapter/package.yaml
@@ -34,5 +34,5 @@ source:
         haskell-debug-adapter: haskell-debug-adapter.exe
 
 bin:
-  ghci-dap: "{{source.build.bin.ghci-dap}}"
-  haskell-debug-adapter: "{{source.build.bin.haskell-debug-adapter}}"
+  ghci-dap: "{{source.build.bin['ghci-dap']}}"
+  haskell-debug-adapter: "{{source.build.bin['haskell-debug-adapter']}}"

--- a/packages/haskell-debug-adapter/package.yaml
+++ b/packages/haskell-debug-adapter/package.yaml
@@ -21,6 +21,7 @@ source:
       env:
         VERSION: "{{version}}"
       bin:
+        stack: stack
         ghci-dap: bin/ghci-dap
         haskell-debug-adapter: bin/haskell-debug-adapter
 
@@ -32,9 +33,11 @@ source:
       env:
         VERSION: "{{version}}"
       bin:
+        stack: stack.exe
         ghci-dap: ghci-dap.exe
         haskell-debug-adapter: haskell-debug-adapter.exe
 
 bin:
+  stack: "{{source.build.bin.stack}}"
   ghci-dap: "{{source.build.bin.ghci-dap}}"
   haskell-debug-adapter: "{{source.build.bin.haskell-debug-adapter}}"


### PR DESCRIPTION
Hi there,

I took some time to put together this port of [phoityne/haskell-debug-adapter](https://github.com/phoityne/haskell-debug-adapter).

I would love for any feedback and/or criticisms so that I can improve the.

Like the haskell-language-server package, haskell-debug-adapter is dependent on ghcup. The package uses ghcup to install a local copy of stack. Stack is then used to build local versions of haskell-dap, ghci-dap, and finally haskell-debug-adapter.

I was unable to test my the windows implementation as I do not have a windows machine with me at the moment. I would greatly appreciate anyone who would be able to test this.