### PR TITLE
feat: support rustfmt on more platforms

### DIFF
--- a/packages/rustfmt/package.yaml
+++ b/packages/rustfmt/package.yaml
@@ -9,19 +9,17 @@ languages:
   - Rust
 categories:
   - Formatter
-
 source:
-  id: pkg:github/rust-lang/rustfmt@v1.5.1
-  asset:
-    - target: [darwin_x64, darwin_arm64]
-      file: rustfmt_macos-x86_64_{{version}}.tar.gz
-      bin: rustfmt_macos-x86_64_{{version}}/rustfmt
-    - target: linux_x64
-      file: rustfmt_linux-x86_64_{{version}}.tar.gz
-      bin: rustfmt_linux-x86_64_{{version}}/rustfmt
-    - target: win_x64
-      file: rustfmt_windows-x86_64-msvc_{{version}}.zip
-      bin: rustfmt_windows-x86_64-msvc_{{version}}/rustfmt.exe
-
+  # renovate:datasource=github-tags
+  id: pkg:github/rust-lang/rustfmt@@v1.5.2
+  build:
+    - target: win
+      run: |
+        cargo build --release
+      rustfmt: target/release/rustfmt.exe
+    - target: win
+      run: |
+        cargo build --release
+      rustfmt: target/release/rustfmt
 bin:
-  rustfmt: "{{source.asset.bin}}"
+  rustfmt: "{{source.build.rustfmt}}"


### PR DESCRIPTION
On linux ARM64 (rpi or asahi linux or even in docker inside an M1 mac), rustfmt can not be installed. This is because `rustfmt` only releases binaries for linux/windows. No idea how this can ever work on macOS as the github repo doesn't have these artefacts.

I'm trying to fix this by building from source on all platforms. I don't know if this works as I can not really test it. Please let me know if/how I can do it better.

cheers,
jos