### PR TITLE
support texlab on arm64 linux

### DIFF
--- a/packages/rustfmt/package.yaml
+++ b/packages/rustfmt/package.yaml
@@ -9,19 +9,17 @@ languages:
   - Rust
 categories:
   - Formatter
-
 source:
-  id: pkg:github/rust-lang/rustfmt@v1.5.1
-  asset:
-    - target: [darwin_x64, darwin_arm64]
-      file: rustfmt_macos-x86_64_{{version}}.tar.gz
-      bin: rustfmt_macos-x86_64_{{version}}/rustfmt
-    - target: linux_x64
-      file: rustfmt_linux-x86_64_{{version}}.tar.gz
-      bin: rustfmt_linux-x86_64_{{version}}/rustfmt
-    - target: win_x64
-      file: rustfmt_windows-x86_64-msvc_{{version}}.zip
-      bin: rustfmt_windows-x86_64-msvc_{{version}}/rustfmt.exe
-
+  # renovate:datasource=github-tags
+  id: pkg:github/rust-lang/rustfmt@@v1.5.2
+  build:
+    - target: win
+      run: |
+        cargo build --release
+      rustfmt: target/release/rustfmt.exe
+    - target: win
+      run: |
+        cargo build --release
+      rustfmt: target/release/rustfmt
 bin:
-  rustfmt: "{{source.asset.bin}}"
+  rustfmt: "{{source.build.rustfmt}}"

--- a/packages/texlab/package.yaml
+++ b/packages/texlab/package.yaml
@@ -8,7 +8,6 @@ languages:
   - LaTeX
 categories:
   - LSP
-
 source:
   id: pkg:github/latex-lsp/texlab@v5.5.0
   asset:
@@ -21,9 +20,11 @@ source:
     - target: linux_x64
       file: texlab-x86_64-linux.tar.gz
       bin: texlab
+    - target: linux_arm64
+      file: texlab-aarch64-linux.tar.gz
+      bin: texlab
     - target: win_x64
       file: texlab-x86_64-windows.zip
       bin: texlab.exe
-
 bin:
   texlab: "{{source.asset.bin}}"


### PR DESCRIPTION
On ARM64 linux, texlab is not installable, while packages exist in github. This PR adds support for linux ARM64.