### PR TITLE
feat: add texlab on arm64 linux

### DIFF
--- a/packages/texlab/package.yaml
+++ b/packages/texlab/package.yaml
@@ -18,10 +18,10 @@ source:
     - target: darwin_x64
       file: texlab-x86_64-macos.tar.gz
       bin: texlab
-    - target: linux_x64
+    - target: linux_x64_gnu
       file: texlab-x86_64-linux.tar.gz
       bin: texlab
-    - target: linux_arm64
+    - target: linux_arm64_gnu
       file: texlab-aarch64-linux.tar.gz
       bin: texlab
     - target: win_x64

--- a/packages/texlab/package.yaml
+++ b/packages/texlab/package.yaml
@@ -21,6 +21,9 @@ source:
     - target: linux_x64
       file: texlab-x86_64-linux.tar.gz
       bin: texlab
+    - target: linux_arm64
+      file: texlab-aarch64-linux.tar.gz
+      bin: texlab
     - target: win_x64
       file: texlab-x86_64-windows.zip
       bin: texlab.exe


### PR DESCRIPTION
On ARM64 linux, texlab is not installable, while packages exist in github. This PR adds support for linux ARM64.