### PR TITLE
Update netcoredbg to respect windows style paths

### DIFF
--- a/packages/netcoredbg/package.yaml
+++ b/packages/netcoredbg/package.yaml
@@ -25,7 +25,7 @@ source:
       bin: exec:libexec/netcoredbg/netcoredbg
     - target: win_x64
       file: netcoredbg-win64.zip
-      bin: netcoredbg/netcoredbg.exe
+      bin: netcoredbg\netcoredbg.exe
 
 bin:
   netcoredbg: "{{source.asset.bin}}"


### PR DESCRIPTION
## Overview
Before, the path to the executable for netcoredbg was using `/` rather than `\`. This led to DAP never launching netcoredbg and not working for windows users. This PR fixes that!

## How I got here
I have been using [LazyVim's DAP setup](https://www.lazyvim.org/plugins/extras/dap.core) for out of the box DAP configuration. Launching netcoredbg results in a failure to connect and I found that the path to the executable is being launched like so:
![image](https://user-images.githubusercontent.com/7707706/236105353-85cec645-14fd-4e47-85ec-784980a0d1c0.png)
Thus, I have created this fix PR.