### PR TITLE
Pull request to add Python docstring formatters

### DIFF
--- a/packages/docformatter/package.yaml
+++ b/packages/docformatter/package.yaml
@@ -1,0 +1,16 @@
+---
+name: docformatter
+description: docformatter automatically formats docstrings to follow a subset of the PEP 257 conventions.
+homepage: https://pypi.org/project/docformatter/
+licenses:
+  - MIT
+languages:
+  - Python
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/docformatter@1.6.5
+
+bin:
+  docformatter: pypi:docformatter

--- a/packages/pyment/package.yaml
+++ b/packages/pyment/package.yaml
@@ -1,0 +1,16 @@
+---
+name: pyment
+description: Create, update or convert docstrings in existing Python files, managing several styles.
+homepage: https://pypi.org/project/pyment/
+licenses:
+  - GPL-3.0-only
+languages:
+  - Python
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/pyment@0.3.3
+
+bin:
+  pyment: pypi:pyment


### PR DESCRIPTION
Pull request to add two of the major Python docstring formatting packages to the mason registry, namely:
- [docformatter](https://pypi.org/project/docformatter/), and
- [pyment](https://pypi.org/project/pyment/).

Both packages provide functionality to format docstrings in Python files, with each package providing relative advantages/disadvantages over the other. I expect development pace to vary between the two and that mason users require the option to select a formatter that suits their project's needs. The closest existing package in the [mason registry](https://mason-registry.dev/registry/list) is pydocstyle, however, that package only provides PEP 257 compliance checking, not formatting.

The added package.yaml files follow the package definition scheme, and have been created in unique directories ("docformatter" and "pyment") in accordance with the [contribution guidelines](https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md).