### PR TITLE
fix(salt-lsp): link correct bin name

### DIFF
--- a/packages/salt-lsp/package.yaml
+++ b/packages/salt-lsp/package.yaml
@@ -13,4 +13,4 @@ source:
   id: pkg:pypi/salt-lsp@0.0.1
 
 bin:
-  salt-lsp: pypi:salt_lsp_server
+  salt_lsp_server: pypi:salt_lsp_server


### PR DESCRIPTION
Closes https://github.com/williamboman/mason.nvim/issues/1301.