### PR TITLE
fix smithy language server version

### DIFF
--- a/packages/smithy-language-server/package.yaml
+++ b/packages/smithy-language-server/package.yaml
@@ -11,7 +11,7 @@ categories:
 
 source:
   # renovate:datasource=git-refs
-  id: pkg:github/awslabs/smithy-language-server@e4675485051c4931381470299a7d3ce50408f7c7
+  id: pkg:github/awslabs/smithy-language-server@708bfc4ff8ca1b266a66c9919d269cd74dffe2e1
   build:
     run: ./gradlew --no-daemon build
 


### PR DESCRIPTION
## Problem

I attempted to build the current Smithy language server using the two most recent Java versions, 17 and 20, but neither was successful.

### Old version (e4675485051c4931381470299a7d3ce50408f7c7)
<img width="803" alt="image" src="https://github.com/mason-org/mason-registry/assets/40130936/e5e0d24b-86a2-4774-acf9-a9c3835c5be4">
<img width="976" alt="image" src="https://github.com/mason-org/mason-registry/assets/40130936/226885a6-ac53-4397-9f34-b3a87f0a7dab">


### New version (708bfc4ff8ca1b266a66c9919d269cd74dffe2e1) based on the latest comment
<img width="751" alt="image" src="https://github.com/mason-org/mason-registry/assets/40130936/9af4e534-fc60-4281-ba51-70ce51ab0206">
<img width="759" alt="image" src="https://github.com/mason-org/mason-registry/assets/40130936/f3989f00-a77a-4b32-8590-c4f1832d5a06">

