### PR TITLE
fix(luacheck): update homepage link

### DIFF
--- a/packages/luacheck/package.yaml
+++ b/packages/luacheck/package.yaml
@@ -1,7 +1,7 @@
 ---
 name: luacheck
 description: A tool for linting and static analysis of Lua code.
-homepage: https://github.com/mpeterv/luacheck
+homepage: https://github.com/lunarmodules/luacheck
 licenses:
   - MIT
 languages:


### PR DESCRIPTION
The download source for luacheck is luarocks, for which homepage is the new one

See <https://luarocks.org/modules/lunarmodules/luacheck>