### PR TITLE
chore(renovate): explicitly set managers

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -8,6 +8,7 @@
     prConcurrentLimit: 0,
     branchConcurrentLimit: 0,
     rebaseWhen: "conflicted",
+    enabledManagers: ["regex"],
     regexManagers: [
         {
             fileMatch: "package\\.yaml$",


### PR DESCRIPTION
Hopefully reduces the amount of work done by Renovate.
