### PR TITLE
bump(helm-ls): downgrade to 0.0.3

### DIFF
--- a/packages/helm-ls/package.yaml
+++ b/packages/helm-ls/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/mrjosh/helm-ls@v0.0.4
+  id: pkg:github/mrjosh/helm-ls@v0.0.3
   asset:
     - target: darwin_x64
       file: helm_ls_darwin_amd64


### PR DESCRIPTION
It was using invalid helm-ls version. Version 0.0.4 does not exist.