### PR TITLE
chore: update vue-language-server

### DIFF
--- a/packages/vue-language-server/package.yaml
+++ b/packages/vue-language-server/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:npm/%40vue/language-server@1.7.13
+  id: pkg:npm/%40vue/language-server@1.7.0
   extra_packages:
     - typescript
 

--- a/packages/vue-language-server/package.yaml
+++ b/packages/vue-language-server/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:npm/%40vue/language-server@1.7.0
+  id: pkg:npm/%40vue/language-server@1.7.13
   extra_packages:
     - typescript
 

--- a/renovate.json5
+++ b/renovate.json5
@@ -89,4 +89,11 @@
             versioningTemplate: "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
         },
     ],
+    packageRules: [
+        {
+            matchDatasources: ["npm"],
+            matchPackageNames: ["@vue/language-server"],
+            ignoreUnstable: false
+        }
+    ],
 }


### PR DESCRIPTION
Dependency bot doesn't seem to be pulling in the "pre-release" changes in, for volar, but was manually moved to point to 1.7 due to  package name change. Need to update to latest to fix issues with typescript 5.1.3