### PR TITLE
bump(haskell-language-server): update to v2.0.0.0

### DIFF
--- a/packages/haskell-language-server/package.yaml
+++ b/packages/haskell-language-server/package.yaml
@@ -11,7 +11,7 @@ categories:
 
 source:
   # renovate:datasource=github-releases
-  id: pkg:generic/haskell/haskell-language-server@1.10.0.0
+  id: pkg:generic/haskell/haskell-language-server@2.0.0.0
   build:
     - target: unix
       run: ghcup install hls "$VERSION" -i "$PWD"
@@ -23,7 +23,7 @@ source:
         server_8_10_7: bin/haskell-language-server-8.10.7
         server_9_0_2: bin/haskell-language-server-9.0.2
         server_9_2_7: bin/haskell-language-server-9.2.7
-        server_9_4_4: bin/haskell-language-server-9.4.4
+        server_9_4_5: bin/haskell-language-server-9.4.5
         server_9_6_1: bin/haskell-language-server-9.6.1
 
     - target: win
@@ -36,7 +36,7 @@ source:
         server_8_10_7: haskell-language-server-8.10.7.exe
         server_9_0_2: haskell-language-server-9.0.2.exe
         server_9_2_7: haskell-language-server-9.2.7.exe
-        server_9_4_4: haskell-language-server-9.4.4.exe
+        server_9_4_5: haskell-language-server-9.4.5.exe
         server_9_6_1: haskell-language-server-9.6.1.exe
 
 bin:
@@ -45,5 +45,5 @@ bin:
   # https://github.com/haskell/haskell-language-server/issues/3162
   haskell-language-server-9.0.2: "{{ source.build.bin.server_9_0_2 | take_if_not(is_platform('darwin_arm64')) }}"
   haskell-language-server-9.2.7: "{{source.build.bin.server_9_2_7}}"
-  haskell-language-server-9.4.4: "{{source.build.bin.server_9_4_4}}"
+  haskell-language-server-9.4.5: "{{source.build.bin.server_9_4_5}}"
   haskell-language-server-9.6.1: "{{source.build.bin.server_9_6_1}}"


### PR DESCRIPTION
Not sure why this hasn't been automatically updated, but I recently updated my Mason dependencies and noticed that it downgraded my installed version of HLS. I've temporarily solved this by manually installing it via GHCup, but would prefer for it to work here.