### PR TITLE
use system rustup to get rustfmt

### DIFF
--- a/packages/rustfmt/package.yaml
+++ b/packages/rustfmt/package.yaml
@@ -11,17 +11,12 @@ categories:
   - Formatter
 
 source:
-  id: pkg:github/rust-lang/rustfmt@v1.6.0
-  asset:
-    - target: [darwin_x64, darwin_arm64]
-      file: rustfmt_macos-x86_64_{{version}}.tar.gz
-      bin: rustfmt_macos-x86_64_{{version}}/rustfmt
-    - target: linux_x64
-      file: rustfmt_linux-x86_64_{{version}}.tar.gz
-      bin: rustfmt_linux-x86_64_{{version}}/rustfmt
-    - target: win_x64
-      file: rustfmt_windows-x86_64-msvc_{{version}}.zip
-      bin: rustfmt_windows-x86_64-msvc_{{version}}/rustfmt.exe
+  id: pkg:generic/rustfmt@x
+  build:
+    run: |
+      rustup component add rustfmt
+      cp $(which rustfmt) .
+    bin: rustfmt
 
 bin:
-  rustfmt: "{{source.asset.bin}}"
+  rustfmt: "{{source.build.bin}}"

--- a/packages/rustfmt/package.yaml
+++ b/packages/rustfmt/package.yaml
@@ -13,9 +13,7 @@ categories:
 source:
   id: pkg:generic/rustfmt@x
   build:
-    run: |
-      rustup component add rustfmt
-      cp $(which rustfmt) .
+    run: cp $(which rustfmt) . || echo "rustfmt not found"
     bin: rustfmt
 
 bin:


### PR DESCRIPTION
A first stab at creating a new package.yaml for rustfmt as the current one is broken (see https://github.com/mason-org/mason-registry/issues/2054).

I could not figure out how I can test this.

Please comment on how it could be improved.