### PR TITLE
feat: add emmet-language-server

### DIFF
--- a/packages/emmet-language-server/package.yaml
+++ b/packages/emmet-language-server/package.yaml
@@ -1,0 +1,16 @@
+---
+name: emmet-language-server
+description: A language server for emmet.io.
+homepage: https://github.com/olrtg/emmet-language-server
+licenses:
+  - MIT
+languages:
+  - Emmet
+categories:
+  - LSP
+
+source:
+  id: pkg:npm/@olrtg/emmet-language-server@2.0.0
+
+bin:
+  emmet-language-server: npm:@olrtg/emmet-language-server

--- a/packages/emmet-language-server/package.yaml
+++ b/packages/emmet-language-server/package.yaml
@@ -13,4 +13,4 @@ source:
   id: pkg:npm/@olrtg/emmet-language-server@2.0.0
 
 bin:
-  emmet-language-server: npm:@olrtg/emmet-language-server
+  emmet-language-server: npm:emmet-language-server


### PR DESCRIPTION
Hey! This PR adds a new language server called `emmet-language-server` (an alternative to aca/emmet-ls which already exists in the registry) to the registry.

([repo](https://github.com/olrtg/emmet-language-server))

I wanted to ask also.. if you decide to merge this can you take a careful look to the following (since it's my first time doing this and the `source` and `bin` properties were confusing to me):

- The [package in npm](https://www.npmjs.com/package/@olrtg/emmet-language-server) is under `@olrtg/emmet-language-server`
- The command can be called just with `emmet-language-server`