### PR TITLE
feat: add mdformat

### DIFF
--- a/packages/mdformat/package.yaml
+++ b/packages/mdformat/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: mdformat
-description: CommonMark compliant Markdown formatter
+description: CommonMark compliant Markdown formatter.
 homepage: https://github.com/executablebooks/mdformat
 licenses:
   - MIT

--- a/packages/mdformat/package.yaml
+++ b/packages/mdformat/package.yaml
@@ -1,0 +1,17 @@
+---
+name: mdformat
+description: CommonMark compliant Markdown formatter
+
+homepage: https://github.com/executablebooks/mdformat
+licenses:
+  - MIT
+languages:
+  - Markdown
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/mdformat@0.7.16
+
+bin:
+  mdformat: pypi:mdformat

--- a/packages/mdformat/package.yaml
+++ b/packages/mdformat/package.yaml
@@ -1,7 +1,6 @@
 ---
 name: mdformat
 description: CommonMark compliant Markdown formatter
-
 homepage: https://github.com/executablebooks/mdformat
 licenses:
   - MIT


### PR DESCRIPTION
[`mdformat`](https://github.com/executablebooks/mdformat) is a Markdown formatter written in Python that is extensible using plugins.