### PR TITLE
feat: add pyright-python

### DIFF
--- a/packages/pyright-python/package.yaml
+++ b/packages/pyright-python/package.yaml
@@ -1,0 +1,20 @@
+---
+name: pyright-python
+description: Static type checker for Python - in a Python wrapper.
+homepage: https://github.com/RobertCraigie/pyright-python
+licenses:
+  - MIT
+languages:
+  - Python
+categories:
+  - LSP
+
+source:
+  id: pkg:pypi/pyright@1.1.317
+
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/microsoft/pyright/{{version}}/packages/vscode-pyright/package.json
+
+bin:
+  pyright-python: pypi:pyright-python
+  pyright-python-langserver: pypi:pyright-python-langserver


### PR DESCRIPTION
Reasoning: https://github.com/RobertCraigie/pyright-python is an unofficial Python wrapper for Pyright, that installs node and npm in a small venv in and runs Pyright from there.

It's been discussed earlier in [this issue](https://github.com/williamboman/mason.nvim/issues/424), when the registry was a part of Mason proper. I don't know for how long, but the wrapper has 2 extra executables, `pyright-python` and `pyright-python-langserver`, which are identical to the originally called ones. To avoid conflict with original Pyright, this commit of mine will only expose `..-python` executables to `mason/bin`.

A parallel PR was created at [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/pull/2718)