### PR TITLE
fix(angular-language-server): pin typescript to 4.8.2

### DIFF
--- a/packages/angular-language-server/package.yaml
+++ b/packages/angular-language-server/package.yaml
@@ -14,7 +14,7 @@ categories:
 source:
   id: pkg:npm/%40angular/language-server@16.0.0
   extra_packages:
-    - typescript
+    - typescript@4.8.2
 
 bin:
   ngserver: npm:ngserver


### PR DESCRIPTION
Fixes https://github.com/williamboman/mason.nvim/issues/1404.