### PR TITLE
feat: add vscode-java-decompiler jars.

### DIFF
--- a/packages/vscode-java-decompiler/package.yaml
+++ b/packages/vscode-java-decompiler/package.yaml
@@ -1,0 +1,23 @@
+---
+name: vscode-java-decompiler
+description: |
+  Decompiler jars from the Decompiler extension for Java in Visual Studio Code.
+  The Java source code is available in the https://github.com/dgileadi/dg.jdt.ls.decompiler repo.
+homepage: https://github.com/dgileadi/vscode-java-decompiler
+licenses:
+  - EPL-2.0
+languages:
+  - Java
+categories:
+  - DAP
+
+source:
+  # renovate:datasource=git-refs
+  id: pkg:github/dgileadi/vscode-java-decompiler@5eaf2fcf73ba6763f1eba69047f631fba80f9a50
+  build:
+    # This repository has the jars pre-built and committed, but there is no repository releases.
+    # Adding this here because it is required by the schema.
+    run: ''
+
+share:
+  vscode-java-decompiler/bundles/: 'server/'


### PR DESCRIPTION
Just saw https://github.com/williamboman/mason.nvim/issues/193 and decided to try to make a package for it.

**Some notes:**
Since the [vscode-java-decompiler](https://github.com/dgileadi/vscode-java-decompiler) repository has the required `jar` files already committed in, I have left the `run` empty since it's required by the `yaml` spec.

Tried the workflow on my fork and it seems to pass the tests. Although admittedly, I don't know how to test this out on my local machine.