### PR TITLE
fix(semgrep): also link pysemgrep executable

### DIFF
--- a/packages/semgrep/package.yaml
+++ b/packages/semgrep/package.yaml
@@ -27,3 +27,4 @@ source:
 
 bin:
   semgrep: pypi:semgrep
+  pysemgrep: pypi:pysemgrep


### PR DESCRIPTION
Closes https://github.com/williamboman/mason.nvim/issues/1418.
