### PR TITLE
feat(markdown): add doctoc

### DIFF
--- a/packages/doctoc/package.yaml
+++ b/packages/doctoc/package.yaml
@@ -1,0 +1,16 @@
+---
+name: doctoc
+description: API and CLI for generating a markdown TOC (table of contents) for a README or any markdown files.
+homepage: https://github.com/thlorenz/doctoc
+licenses:
+  - MIT
+languages:
+  - Markdown
+categories:
+  - Formatter
+
+source:
+  id: pkg:npm/doctoc@2.2.1
+
+bin:
+  doctoc: npm:doctoc


### PR DESCRIPTION
CLI for generating markdown table of contents.

Supports github, gitlab, & bitbucket