### PR TITLE
feat: add ripper-tags

### DIFF
--- a/packages/ripper-tags/package.yaml
+++ b/packages/ripper-tags/package.yaml
@@ -1,7 +1,6 @@
 ---
 name: ripper-tags
-description: |
-  fast, accurate ctags generator for ruby source code using Ripper
+description: fast, accurate ctags generator for ruby source code using Ripper.
 homepage: https://github.com/tmm1/ripper-tags
 licenses:
   - MIT

--- a/packages/ripper-tags/package.yaml
+++ b/packages/ripper-tags/package.yaml
@@ -1,0 +1,16 @@
+---
+name: ripper-tags
+description: |
+  fast, accurate ctags generator for ruby source code using Ripper
+homepage: https://github.com/tmm1/ripper-tags
+licenses:
+  - MIT
+languages:
+  - Ruby
+categories: []
+
+source:
+  id: pkg:gem/ripper-tags@1.0.1
+
+bin:
+  ripper-tags: gem:ripper-tags


### PR DESCRIPTION
Add [ripper-tags](https://github.com/tmm1/ripper-tags) gem which is used to generate ctags for Ruby file types.

**Help Wanted:**

I'm unsure how I can test this. I thought I could add my fork as a registry but I'm getting this error:

```
 Uninstalled registries
  Packages from the following registries are unavailable. Press C to install.
   - github.com/wassimk/mason-registry [uninstalled]
  
  Registry installation failed with the following error:
    GitHubRegistrySource(repo=wassimk/mason-registry) failed to install: Failed to download registry archive.
```


