### PR TITLE
Updated ZLS to build directly from source.

### DIFF
--- a/packages/zls/package.yaml
+++ b/packages/zls/package.yaml
@@ -10,38 +10,15 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/zigtools/zls@0.10.0
-  asset:
-    - target: darwin_arm64
-      file: aarch64-macos.tar.zst
-      bin: bin/zls
-    - target: darwin_x64
-      file: x86_64-macos.tar.zst
-      bin: bin/zls
-    - target: linux_x64
-      file: x86_64-linux.tar.zst
-      bin: bin/zls
-    - target: linux_x86
-      file: i386-linux.tar.zst
-      bin: bin/zls
-    - target: win_x86
-      file: i386-windows.tar.zst
-      bin: bin/zls.exe
-    - target: win_x64
-      file: x86_64-windows.tar.zst
-      bin: bin/zls.exe
+  # renovate:datasource=git-refs
+  id: pkg:github/zigtools/zls@d1d4e60d543812231e3afe977f32fc6846c83962
+  build:
+    run: |
+      zig build -Doptimize=ReleaseSafe
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/zigtools/zls-vscode/master/package.json
 
 bin:
-  zls: "{{source.asset.bin}}"
+  zls: "zig-out/bin/zls"
 
-# zstd is unavailable on runners.
-ci_skip:
-  - darwin_x64
-  - darwin_arm64
-  - win_arm
-  - win_arm64
-  - win_x64
-  - win_x86


### PR DESCRIPTION
[ZLS](https://github.com/zigtools/zls) releases seem to have remained stuck to the 0.10.0 version released in **November 2022**.
I have corrected the package manifest so that ZLS is built from source according to the README.md.

**A few questions remain:**
- Is this the appropriate way to define/freeze a ZLS version? By specifying a commit hash (which was the latest commit at the time of this PR.)? If so, would we need to update the version every once-in-a-while?
- What would be the best way to handle the dependency on the latest Zig compiler? Usually the latest Zig Language Server needs the latest Zig compiler to build (0.11.0 as of 7 august 2023). It works on my machine™ since I have the latest Zig compiler, but other people might not have the latest one.