### PR TITLE
Revert wrong renovate update to debugpy

### DIFF
--- a/packages/debugpy/package.yaml
+++ b/packages/debugpy/package.yaml
@@ -10,7 +10,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:pypi/debugpy@1.6.8
+  id: pkg:pypi/debugpy@1.6.7
 
 bin:
   debugpy: pyvenv:debugpy


### PR DESCRIPTION
The debugpy team tested their release pipeline and this new release triggered renovate (see PR ##2344) to update `debugpy` to v1.6.8 which does not exist on `pypi`. 

This fixes issue #2381

_Note: I would have liked to find a way to prevent renovate from doing this in the future, but didn't fully understand the configuration. To me it looks like you already use the `pypi` datasourceTemplate for this and therefore I don't exactly know if this can be prevented on `mason-registry`'s side._