### PR TITLE
chore(ruff,ruff-lsp): update homepage links

### DIFF
--- a/packages/ruff-lsp/package.yaml
+++ b/packages/ruff-lsp/package.yaml
@@ -1,7 +1,7 @@
 ---
 name: ruff-lsp
 description: A Language Server Protocol implementation for Ruff - An extremely fast Python linter, written in Rust.
-homepage: https://github.com/charliermarsh/ruff-lsp/
+homepage: https://github.com/astral-sh/ruff-lsp/
 licenses:
   - MIT
 languages:

--- a/packages/ruff/package.yaml
+++ b/packages/ruff/package.yaml
@@ -1,7 +1,7 @@
 ---
 name: ruff
 description: An extremely fast Python linter, written in Rust.
-homepage: https://github.com/charliermarsh/ruff/
+homepage: https://github.com/astral-sh/ruff/
 licenses:
   - MIT
 languages:


### PR DESCRIPTION
These are now hosted under the astral-sh org on GitHub.