### PR TITLE
chore(zls): update lsp schema location

### DIFF
--- a/packages/zls/package.yaml
+++ b/packages/zls/package.yaml
@@ -32,7 +32,7 @@ source:
       bin: bin/zls.exe
 
 schemas:
-  lsp: vscode:https://raw.githubusercontent.com/zigtools/zls-vscode/master/package.json
+  lsp: vscode:https://raw.githubusercontent.com/ziglang/vscode-zig/master/package.json
 
 bin:
   zls: "{{source.asset.bin}}"


### PR DESCRIPTION
Fixes #2430. This is supposed to improve DX and performance when using zls in neovim.