### PR TITLE
fix(angular-language-server): outdated typescript version for v16.1.8

### DIFF
--- a/packages/angular-language-server/package.yaml
+++ b/packages/angular-language-server/package.yaml
@@ -14,7 +14,7 @@ categories:
 source:
   id: pkg:npm/%40angular/language-server@16.1.8
   extra_packages:
-    - typescript@4.8.2
+    - typescript@5.1.3
 
   version_overrides:
     - constraint: semver:<=14.1.0


### PR DESCRIPTION
Otherwise language server fails to start with following error:
```
"rpc"	"ngserver"	"stderr"	"/home/user/.local/share/nvim/mason/packages/angular-language-server/node_modules/@angular/language-server/index.js:235\n      throw new Error(`Failed to resolve '${packageName}' with minimum version '${minVersion}' from ` + JSON.stringify(probeLocations, null, 2));
```

Plus it's specified in language-server's release notes (via #2398):
> Update the bundled version of TypeScript to 5.1.3