### PR TITLE
bump(zls): update to v0.11.0

### DIFF
--- a/packages/zls/package.yaml
+++ b/packages/zls/package.yaml
@@ -39,12 +39,3 @@ schemas:
 
 bin:
   zls: "{{source.asset.bin}}"
-
-# zstd is unavailable on runners.
-ci_skip:
-  - darwin_x64
-  - darwin_arm64
-  - win_arm
-  - win_arm64
-  - win_x64
-  - win_x86

--- a/packages/zls/package.yaml
+++ b/packages/zls/package.yaml
@@ -10,25 +10,28 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/zigtools/zls@0.10.0
+  id: pkg:github/zigtools/zls@0.11.0
   asset:
     - target: darwin_arm64
-      file: aarch64-macos.tar.zst
+      file: zls-aarch64-macos.tar.gz
       bin: bin/zls
     - target: darwin_x64
-      file: x86_64-macos.tar.zst
+      file: zls-x86_64-macos.tar.gz
+      bin: bin/zls
+    - target: linux_arm64
+      file: zls-aarch64-linux.tar.gz
       bin: bin/zls
     - target: linux_x64
-      file: x86_64-linux.tar.zst
+      file: zls-x86_64-linux.tar.gz
       bin: bin/zls
     - target: linux_x86
-      file: i386-linux.tar.zst
+      file: zls-x86-linux.tar.gz
       bin: bin/zls
     - target: win_x86
-      file: i386-windows.tar.zst
+      file: zls-x86-windows.zip
       bin: bin/zls.exe
     - target: win_x64
-      file: x86_64-windows.tar.zst
+      file: zls-x86_64-windows.zip
       bin: bin/zls.exe
 
 schemas:


### PR DESCRIPTION
Changed version number for the `zls` package to the latest (0.11.0). Latest package source archives no longer use zstd and are now packaged in gzipped tarballs and `.zip` files on Windows.

Also removed the `ci_skip` entries, as they were added there because the source archives where `.tar.zst`.