### PR TITLE
bump(nil): update to 2023-08-09

### DIFF
--- a/packages/nil/package.yaml
+++ b/packages/nil/package.yaml
@@ -12,7 +12,7 @@ categories:
 
 source:
   # renovate:versioning=loose
-  id: pkg:cargo/nil@2022-12-01?repository_url=https://github.com/oxalica/nil
+  id: pkg:cargo/nil@2023-08-09?repository_url=https://github.com/oxalica/nil
 
 bin:
   nil: cargo:nil


### PR DESCRIPTION
First of all, I am very happy with Mason. Thanks for this package!

I noticed that the Nil language for server is incompatible with newer versions of Nix. When building the version from Mason it fails. The fix incorporated in this newer version and should be backwards compatible. See oxalica/nil#93 for more context.

This also bumps to the latest version. There are more tags possible, I just picked the latest version of the language server. The tags are listed here: [oxalica/nil/tags](https://github.com/oxalica/nil/tags)

EDIT: I see I mistakenly tagged a PR in my commit message 🙃, I'll edit that on merge. 