### PR TITLE
schemas: add support for swift based components

### DIFF
--- a/schemas/components/source.json
+++ b/schemas/components/source.json
@@ -14,7 +14,8 @@
                 { "$ref": "sources/npm" },
                 { "$ref": "sources/nuget" },
                 { "$ref": "sources/opam" },
-                { "$ref": "sources/pypi" }
+                { "$ref": "sources/pypi" },
+                { "$ref": "sources/swift" }
             ]
         }
     },

--- a/schemas/components/sources/swift.json
+++ b/schemas/components/sources/swift.json
@@ -1,0 +1,19 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": "https://json.schemastore.org/mason-registry.json/components/sources/swift",
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+        "id": {
+            "type": "string",
+            "pattern": "^pkg:swift/.+/.+@.+"
+        },
+        "extra_packages": {
+            "type": "array",
+            "description": "Extra swift packages required by the main package to function.",
+            "items": {
+                "type": "string"
+            }
+        }
+    }
+}

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -145,6 +145,7 @@
         "Starlark",
         "Stylelint",
         "Svelte",
+        "Swift",
         "SystemVerilog",
         "TOML",
         "Teal",


### PR DESCRIPTION
I want to add support for swift to mason-lspconfig, and noticed that the first step is to add the schema of swift based components.
Afterwards we can add the package entry for [sourcekit-lsp](https://github.com/apple/sourcekit-lsp) which is the LSP for swift.
And then the PR on the mason-lspconfig repo adding the mapping to the mason package.

This PR (hopefully) takes care of that first, step but since this is my first PR in this repository I'm not very familiar to all the ins and outs, I expect it to need a bit more changes.

Also I based the PURL on the ones used for golang since golang like swift makes use of packages. (Though I'm not very familiar with swift, in fact I just started learning it recently)
