### PR TITLE
packages: Add sourcekit-lsp for Swift

### DIFF
--- a/packages/sourcekit-lsp/package.yaml
+++ b/packages/sourcekit-lsp/package.yaml
@@ -1,0 +1,17 @@
+---
+name: sourcekit-lsp
+description: |
+  Language Server Protocol implementation for Swift and C-based languages.
+homepage: https://github.com/apple/sourcekit-lsp
+licenses:
+  - Apache-2.0
+languages:
+  - Swift
+categories:
+  - LSP
+
+source:
+  id: pkg:swift/github.com/apple/sourcekit-lsp@swift-5.8.1-RELEASE
+
+bin:
+  sourcekit-lsp: .build/debug/sourcekit-lsp


### PR DESCRIPTION
This adds sourcekit-lsp to the mason-registry and depends on #2545 for passing the schema validation checks.

I actually haven't checked the sourcekit-lsp path (`.build/debug/sourcekit-lsp`) since I haven't been able to run a successful build on Linux but I took this from their [documentation development steps](https://github.com/apple/sourcekit-lsp/blob/main/Documentation/Development.md)