### PR TITLE
feat: add `stylelint` addons and `bibtex-tidy`

### DIFF
--- a/packages/bibtex-tidy/package.yaml
+++ b/packages/bibtex-tidy/package.yaml
@@ -1,0 +1,16 @@
+---
+name: stylelint-config-standard
+description: The standard shareable config for Stylelint
+homepage: https://github.com/stylelint/stylelint-config-standard
+licenses:
+  - MIT
+languages:
+  - CSS
+  - Sass
+  - SCSS
+  - LESS
+categories:
+  - Linter
+
+source:
+  id: pkg:npm/stylelint-config-standard@34.0.0

--- a/packages/stylelint-config-recess-order/package.yaml
+++ b/packages/stylelint-config-recess-order/package.yaml
@@ -1,0 +1,16 @@
+---
+name: stylelint-config-recess-order
+description: Recess-based property sort order for Stylelint.
+homepage: https://github.com/stormwarning/stylelint-config-recess-order
+licenses:
+  - ISC
+languages:
+  - CSS
+  - Sass
+  - SCSS
+  - LESS
+categories:
+  - Linter
+
+source:
+  id: pkg:npm/stylelint-config-recess-order@4.3.0

--- a/packages/stylelint-config-standard/package.yaml
+++ b/packages/stylelint-config-standard/package.yaml
@@ -1,0 +1,16 @@
+---
+name: bibtex-tidy
+description: Cleaner and Formatter for BibTeX files
+homepage: https://github.com/FlamingTempura/bibtex-tidy
+licenses:
+  - MIT
+languages:
+  - LaTeX
+categories:
+  - Formatter
+
+source:
+  id: pkg:npm/bibtex-tidy@1.11.0
+
+bin:
+  bibtex-tidy: npm:bibtex-tidy

--- a/packages/stylelint-order/package.yaml
+++ b/packages/stylelint-order/package.yaml
@@ -1,0 +1,17 @@
+---
+name: stylelint
+description: A plugin pack of order related linting rules for Stylelint.
+homepage: https://github.com/hudochenkov/stylelint-order
+licenses:
+  - MIT
+languages:
+  - CSS
+  - Sass
+  - SCSS
+  - LESS
+categories:
+  - Linter
+  - Formatter
+
+source:
+  id: pkg:npm/stylelint-order@6.0.3


### PR DESCRIPTION
- `stylelint` is commonly used with a config (since it has no rules enabled by default) and the `stylelint-order` plugin. Without having them in mason, too, mason's `stylelint` often cannot be used. I chose to add the most common config (recommended by stylelint in their getting started guide), and the by far most common plugin (with config), to not open the gate to add every negligible plugin of a linter.
- Also, I added `bibtex-tidy`. It's actually a formatter for `bibtex` files, but the schema only accepts `latex`, so that's what I filled in for now to conform with the schema.