### PR TITLE
feat: add blueprint

### DIFF
--- a/packages/blueprint/package.yaml
+++ b/packages/blueprint/package.yaml
@@ -1,0 +1,28 @@
+---
+name: blueprint_ls
+description: Language server for Blueprint, a markup language and compiler for GTK 4 user interfaces.
+homepage: https://gitlab.gnome.org/jwestman/blueprint-compiler
+licenses:
+  - LGPL-3.0-or-later
+languages:
+  - Blueprint
+categories:
+  - LSP
+
+source:
+  id: pkg:generic/blueprint?vcs_url=git%2Bhttps://gitlab.gnome.org/jwestman/blueprint-compiler%402a39a16391122af2f3d812e478c1c1398c98b972
+  build:
+    - target: unix
+      run: |
+        meson -Dprefix="$PWD" build
+        ninja -C build install
+      bin: bin/blueprint-compiler
+    - target: win
+      run: |
+        meson -Dprefix="($pwd).path" build
+        ninja -C build install
+      bin: bin/blueprint-compiler.exe
+
+
+bin:
+    blueprint-compiler: "{{source.build.bin}}"

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -20,6 +20,7 @@
         "Beancount",
         "Bicep",
         "Blade",
+        "Blueprint",
         "BrighterScript",
         "C",
         "C#",


### PR DESCRIPTION
Adds the [Blueprint Language Server](https://gitlab.gnome.org/jwestman/blueprint-compiler), closing https://github.com/williamboman/mason.nvim/issues/412.
This is marked as a draft, as I neither tested the code locally, nor does it actually work.
The Blueprint language server is distributed in the same binary as the compiler, and can be started with the `--lsp` flag. Is there any way to add a flag to the executed binary? The [Contributing guide](https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md) did not mention any.