### PR TITLE
Remove Java dependency from ltex-ls on Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,4 +13,3 @@
 Refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution guidelines.
 
 Compiled registry contents are available via [releases](https://github.com/mason-org/mason-registry/releases).
-

--- a/README.md
+++ b/README.md
@@ -13,3 +13,4 @@
 Refer to [CONTRIBUTING.md](./CONTRIBUTING.md) for contribution guidelines.
 
 Compiled registry contents are available via [releases](https://github.com/mason-org/mason-registry/releases).
+

--- a/packages/ltex-ls/package.yaml
+++ b/packages/ltex-ls/package.yaml
@@ -21,7 +21,7 @@ source:
         lsp: ltex-ls-{{version}}/bin/ltex-ls
         cli: ltex-ls-{{version}}/bin/ltex-cli
     - target: win
-      file: ltex-ls-{{version}}.tar.gz
+      file: ltex-ls-{{version}}-windows-x64.zip
       bin:
         lsp: ltex-ls-{{version}}/bin/ltex-ls.bat
         cli: ltex-ls-{{version}}/bin/ltex-cli.bat


### PR DESCRIPTION
Mason currently uses the platform-independent release for ltex-ls. As per [documentation](https://valentjn.github.io/ltex/ltex-ls/installation.html) this is not the recommended approach:

> It’s recommended that you choose the archive corresponding to your platform (these archives are standalone, no Java installation necessary).
If you choose the platform-independent file ltex-ls-VERSION.tar.gz, then you need Java 11 or later on your computer.

I've only updated the Windows asset but would also be happy to do the same testing on a Linux machine and open another PR if this is approved and merged.

One thing I noticed when testing this is I had to update the default cmd (`ltex-ls`) to the following in my config:

```lua
    -- Ltex LS (LanguageTool)
    local ltex_cmd = vim.fn.stdpath("data") .. "/mason/packages/ltex-ls/ltex-ls-16.0.0/bin/ltex-ls"
    require("lspconfig").ltex.setup({
      cmd = { ltex_cmd },
      settings = {
        ltex = {
          language = "en-GB",
        }
      }
    })
```

Not sure if this is a mason-lspconfig issue or if it's because I've pointed mason at my forked registry. Just mentioning in case this causes problems for others. 

Apart from that, everything else appears to be working as expected. 