### PR TITLE
feat: add swift-mesonlsp

### DIFF
--- a/packages/meson-language-server/package.yaml
+++ b/packages/meson-language-server/package.yaml
@@ -1,0 +1,26 @@
+---
+name: meson-language-server
+description: A language server for meson
+homepage: https://github.com/JCWasmx86/Swift-MesonLSP
+licenses:
+  - GPL-3.0
+languages:
+  - Meson
+categories:
+  - LSP
+
+source:
+  id: pkg:github/JCWasmx86/Swift-MesonLSP@v2.4.2
+  asset:
+    - target: linux_x64
+      file: Swift-MesonLSP.zip
+      bin: Swift-MesonLSP
+    - target: darwin
+      file: Swift-MesonLSP-macos13.zip
+      bin: Swift-MesonLSP
+    - target: win_x64
+      file: Swift-MesonLSP-win64.zip
+      bin: Swift-MesonLSP.exe
+
+bin:
+  Swift-MesonLSP: "{{source.asset.bin}}"

--- a/packages/swift-mesonlsp/package.yaml
+++ b/packages/swift-mesonlsp/package.yaml
@@ -1,6 +1,6 @@
 ---
-name: meson-language-server
-description: A language server for meson
+name: swift-mesonlsp
+description: An unofficial, unendorsed language server for meson written in Swift.
 homepage: https://github.com/JCWasmx86/Swift-MesonLSP
 licenses:
   - GPL-3.0
@@ -12,7 +12,7 @@ categories:
 source:
   id: pkg:github/JCWasmx86/Swift-MesonLSP@v2.4.2
   asset:
-    - target: linux_x64
+    - target: linux_x64_gnu
       file: Swift-MesonLSP.zip
       bin: Swift-MesonLSP
     - target: darwin

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -93,6 +93,7 @@
         "MDX",
         "Markdown",
         "Matlab",
+        "Meson",
         "Metamath Zero",
         "Mksh",
         "Move",


### PR DESCRIPTION
Adds [Swift-MesonLSP](https://github.com/JCWasmx86/Swift-MesonLSP), a language server for the meson build system.