### PR TITLE
feat: add darker

### DIFF
--- a/packages/darker/package.yaml
+++ b/packages/darker/package.yaml
@@ -1,0 +1,16 @@
+---
+name: darker
+description: Apply black reformatting to Python files only in regions changed since a given commit.
+homepage: https://pypi.org/project/darker/
+licenses:
+  - BSD-3-Clause
+languages:
+  - Python
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/darker@1.7.2?extra=isort,flynt
+
+bin:
+  darker: pypi:darker


### PR DESCRIPTION
[darker](https://github.com/akaihola/darker) runs [black](https://github.com/psf/black) only on the changed lines in a git repo. Useful in situations where the whole repo hasn't been painted black for one reason or another but you still want to be able to run autoformatter on changes you made.