### PR TITLE
feat: fetch efm binaries from github

### DIFF
--- a/packages/efm/package.yaml
+++ b/packages/efm/package.yaml
@@ -9,7 +9,26 @@ categories:
   - LSP
 
 source:
-  id: pkg:golang/github.com/mattn/efm-langserver@v0.0.48
+  id: pkg:github/mattn/efm-langserver@v0.0.48
+  asset:
+    - target: darwin_x64
+      file: efm-langserver_{{version}}_darwin_amd64.zip
+      bin: efm-langserver_{{version}}_darwin_amd64/efm-langserver
+    - target: darwin_arm64
+      file: efm-langserver_{{version}}_darwin_arm64.zip
+      bin: efm-langserver_{{version}}_darwin_arm64/efm-langserver
+    - target: linux_x64
+      file: efm-langserver_{{version}}_linux_amd64.tar.gz
+      bin: efm-langserver
+    - target: linux_arm64
+      file: efm-langserver_{{version}}_linux_arm64.tar.gz
+      bin: efm-langserver
+    - target: win_x64
+      file: efm-langserver_{{version}}_windows_amd64.zip
+      bin: efm-langserver_{{version}}_windows_amd64/efm-langserver.exe
+    - target: win_arm64
+      file: efm-langserver_{{version}}_windows_arm64.zip
+      bin: efm-langserver_{{version}}_windows_arm64/efm-langserver.exe
 
 bin:
-  efm-langserver: golang:efm-langserver
+  efm-langserver: "{{source.asset.bin}}"

--- a/packages/efm/package.yaml
+++ b/packages/efm/package.yaml
@@ -19,10 +19,10 @@ source:
       bin: efm-langserver_{{version}}_darwin_arm64/efm-langserver
     - target: linux_x64
       file: efm-langserver_{{version}}_linux_amd64.tar.gz
-      bin: efm-langserver
+      bin: efm-langserver_{{version}}_linux_amd64/efm-langserver
     - target: linux_arm64
       file: efm-langserver_{{version}}_linux_arm64.tar.gz
-      bin: efm-langserver
+      bin: efm-langserver_{{version}}_linux_arm64/efm-langserver
     - target: win_x64
       file: efm-langserver_{{version}}_windows_amd64.zip
       bin: efm-langserver_{{version}}_windows_amd64/efm-langserver.exe


### PR DESCRIPTION
Previously, efm was installed via the golang package manager. However, not all users will have the `go` executable installed on their machines.

Latest release: https://github.com/mattn/efm-langserver/releases/tag/v0.0.48