### PR TITLE
bump(java-test): update to v0.40.0

### DIFF
--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -21,7 +21,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:github/microsoft/vscode-java-test@0.39.0
+  id: pkg:github/microsoft/vscode-java-test@0.40.0
   asset:
     file: vscjava.vscode-java-test-{{version}}.vsix
 


### PR DESCRIPTION
java-test needs an update to properly communicate with java-debug-adapter (see: microsoft/vscode-java-test#1605).

This is a simple commit to bump the version and fix this issue.