### PR TITLE
Build java-test directly rather than depending on release asset

### DIFF
--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -21,9 +21,11 @@ categories:
   - DAP
 
 source:
-  id: pkg:github/microsoft/vscode-java-test@0.39.0
-  asset:
-    file: vscjava.vscode-java-test-{{version}}.vsix
+  id: pkg:github/microsoft/vscode-java-test@0.40.0
+  build:
+    run: |
+      npm install
+      npm run build-plugin
 
 share:
-  java-test/: extension/server/
+  java-test/extension/server/: server/


### PR DESCRIPTION
Fixes #3036

Mason can't update to `vscode-java-test > 0.39.0` because `vscjava.vscode-java-test-XX.vsix` is no longer included in the release assets.

[microsoft/vscode-java-test#1594](https://github.com/microsoft/vscode-java-test/issues/1594#issuecomment-1670522559) instructs users to build it themselves by following their GitHub Workflow script. Specifically, the command [`npm run build-plugin`](https://github.com/microsoft/vscode-java-test/blob/main/.github/workflows/build.yml#L40-L41) generates all of the `.jar` files in the `server/` directory.

Unfortunately, this directory is different than `extension/server/`. This would break pretty much every plugin depending on the location of those `.jar` files.

I can only think to add additional `build.run` steps to move to the expected directory in a platform-independent way. I'm not sure if that's desired/necessary, or maybe there's an existing way to correct this behavior? I tried exporting to the correct `share/` directory, but the plugin I've been testing with, LazyVim, depends on the install location not the share location.

Would appreciate some guidance here!