### PR TITLE
fix(cfn-lint): add missing language

### DIFF
--- a/packages/cfn-lint/package.yaml
+++ b/packages/cfn-lint/package.yaml
@@ -9,6 +9,7 @@ licenses:
 languages:
   - YAML
   - JSON
+  - CloudFormation
 categories:
   - Linter
 


### PR DESCRIPTION
 **CloudFormation** Linter.
 https://github.com/aws-cloudformation/cfn-lint
 
![image](https://github.com/mason-org/mason-registry/assets/82561297/b8fe7318-fc25-4480-9dd1-8dcb4b39e9b6)
