### PR TITLE
add easy-coding-standard

### DIFF
--- a/packages/easy-coding-standard/package.yaml
+++ b/packages/easy-coding-standard/package.yaml
@@ -1,0 +1,21 @@
+---
+name: easy-coding-standard
+description: Use Coding Standard with 0-knowledge of PHP-CS-Fixer and PHP_CodeSniffer.
+homepage: https://github.com/easy-coding-standard/easy-coding-standard
+licenses:
+  - MIT
+languages:
+  - PHP
+categories:
+  - Formatter
+  - Linter
+
+source:
+  id: pkg:composer/symplify/easy-coding-standard@12.0.8
+
+bin:
+  ecs: composer:ecs
+
+ci_skip:
+  # freezes on Windows CI for some reason
+  - win_x64


### PR DESCRIPTION
Sorry for bumping, I've accidentally closed #2804 

There was a [problem](https://github.com/mason-org/mason-registry/actions/runs/6240396709/attempts/2) with test for win x64

Only two packages in registry use composer so far
`phpactor` - has only support for unix
`psalm` having same problem (see #1209) as `easy-coding-standard`
