### PR TITLE
bump up java-test to 0.40.1

### DIFF
--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -28,4 +28,4 @@ source:
       npm run build-plugin
 
 share:
-  java-test/: extension/server/
+  java-test/: server/

--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -21,9 +21,11 @@ categories:
   - DAP
 
 source:
-  id: pkg:github/microsoft/vscode-java-test@0.39.0
-  asset:
-    file: vscjava.vscode-java-test-{{version}}.vsix
+  id: pkg:github/microsoft/vscode-java-test@0.40.1
+  build:
+    run: |
+      npm install
+      npm run build-plugin
 
 share:
   java-test/: extension/server/


### PR DESCRIPTION
After the removal of .vsix from releases, updating `java-test` is not possible. So, this change will build the package from source. https://github.com/mason-org/mason-registry/issues/3036

IMPORTANT: path to shared `jar`s  in the `vsix` was `java-test/extension/server/*.jar` but when build with source, there is no `extension` directory anymore. This might break existing configs.

Current latest version in Mason-registry also has a bug where there is an error upon test search. https://github.com/microsoft/vscode-java-test/issues/1625 so updating current version is important.