### PR TITLE
Add nilaway linter

### DIFF
--- a/packages/nilaway/package.yaml
+++ b/packages/nilaway/package.yaml
@@ -14,7 +14,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:golang/go.uber.org/nilaway/cmd/nilaway@a267567c6ffff900df0c3394d031ee70079ec8df
+  id: pkg:golang/go.uber.org/nilaway@v0.0.0-20231117175943-a267567c6fff#cmd/nilaway
 
 bin:
   nilaway: golang:nilaway

--- a/packages/nilaway/package.yaml
+++ b/packages/nilaway/package.yaml
@@ -1,0 +1,20 @@
+---
+name: nilaway
+description: |
+  NilAway is a static analysis tool that seeks to help developers avoid
+  nil panics in production by catching them at compile time rather than
+  at runtime.
+homepage: https://github.com/uber-go/nilaway
+licenses:
+  - Apache-2.0
+
+languages:
+  - Go
+categories:
+  - Linter
+
+source:
+  id: pkg:golang/go.uber.org/nilaway/cmd/nilaway@a267567c6ffff900df0c3394d031ee70079ec8df
+
+bin:
+  nilaway: golang:nilaway


### PR DESCRIPTION
[nilaway](https://github.com/uber-go/nilaway) is a static analysis tool that tries to catch nil panic errors in Go.