### PR TITLE
Add vscode-autohotkey2-lsp

### DIFF
--- a/packages/vscode-autohotkey2-lsp/package.yaml
+++ b/packages/vscode-autohotkey2-lsp/package.yaml
@@ -1,0 +1,20 @@
+---
+name: vscode-autohotkey2-lsp
+description: Autohotkey v2 Language Support using vscode-lsp.
+homepage: https://github.com/thqby/vscode-autohotkey2-lsp
+licenses:
+  - LGPL-3.0
+languages:
+  - AutoHotKey
+categories:
+  - LSP
+
+source:
+  # renovate:datasource=git-refs
+  id: pkg:github/thqby/vscode-autohotkey2-lsp@f358179042fd653a2c536ef24bb1b03898dfd5ca
+  build:
+    - target: win
+      run: |
+        cp ./tools/install.js .
+        rm * -Exclude install.js -Recurse -Force
+        node ./install.js


### PR DESCRIPTION
Permission and license from https://github.com/thqby/vscode-autohotkey2-lsp/issues/437 (in Chinese)

The installing method seems a bit strange, but it's already the best I can get.

Tested with manully changing the huge registry.json, seems works.

Some lsp-servers comes with a json file under mason-schema, I didn't really figure out their usages, is the json file necessary?

This is my first pull request ever, hope I did things right!