### PR TITLE
add darwin arm64 for `typos`

### DIFF
--- a/packages/typos/package.yaml
+++ b/packages/typos/package.yaml
@@ -15,6 +15,10 @@ source:
     - target: darwin_x64
       file: typos-{{ version }}-x86_64-apple-darwin.tar.gz
       bin: typos
+    # No arm64 build yet, but does work fine on M1 Mac. See https://github.com/crate-ci/typos/issues/828
+    - target: darwin_arm64
+      file: typos-{{ version }}-x86_64-apple-darwin.tar.gz
+      bin: typos
     - target: linux_x64
       file: typos-{{ version }}-x86_64-unknown-linux-musl.tar.gz
       bin: typos


### PR DESCRIPTION
So `typos` [does not have a dedicated built for arm64](https://github.com/crate-ci/typos/issues/828), but it does work fine on my arm64 machine. 

So I suppose it wouldn't hurt to enable installing it via mason, even if it is not optimized? (Only added support for mac in this PR, since I do not have a linux/windows device and therefore cannot confirm that `typos` works there as well.)

