### PR TITLE
bump(jq-lsp): update to v0.0.0-20231016080857-b4707e7776a4

### DIFF
--- a/packages/jq-lsp/package.yaml
+++ b/packages/jq-lsp/package.yaml
@@ -12,7 +12,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:golang/github.com/wader/jq-lsp@v0.0.0-20221220100930-4aadc9e4bf54
+  id: pkg:golang/github.com/wader/jq-lsp@v0.0.0-20231016080857-b4707e7776a4
 
 bin:
   jq-lsp: golang:jq-lsp


### PR DESCRIPTION
Hello. It looks like this LSP version has never been updated since originally being added. Since then there have been some bug fixes in the LSP.