### PR TITLE
Added support for hdl_checker lsp

### DIFF
--- a/packages/hdl-checker/package.yaml
+++ b/packages/hdl-checker/package.yaml
@@ -1,0 +1,18 @@
+---
+name: hdl-checker
+description: LSP for VHDL/Verilog/SystemVerilog
+homepage: https://pypi.org/project/hdl-checker/
+licenses:
+  - MIT
+languages:
+  - VHDL
+  - Verilog
+  - SystemVerilog
+categories:
+  - LSP
+
+source:
+  id: pkg:pypi/hdl-checker@0.7.4
+
+bin:
+  autopep8: pypi:autopep8

--- a/packages/hdl-checker/package.yaml
+++ b/packages/hdl-checker/package.yaml
@@ -1,9 +1,9 @@
 ---
 name: hdl-checker
-description: LSP for VHDL/Verilog/SystemVerilog
+description: HDL Checker is a language server that wraps VHDL/Verilg/SystemVerilog tools that aims to reduce the boilerplate code needed to set things up
 homepage: https://pypi.org/project/hdl-checker/
 licenses:
-  - MIT
+  - GPL-3.0
 languages:
   - VHDL
   - Verilog
@@ -15,4 +15,4 @@ source:
   id: pkg:pypi/hdl-checker@0.7.4
 
 bin:
-  autopep8: pypi:autopep8
+  hdl_checker: pypi:hdl_checker

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -162,6 +162,8 @@
         "Typst",
         "V",
         "Vala",
+        "VHDL",
+        "Verilog",
         "Veryl",
         "VimScript",
         "Visualforce",


### PR DESCRIPTION
added [HDL_checker](https://github.com/suoto/hdl_checker) to mason registry.

goes together with [this](https://github.com/williamboman/mason-lspconfig.nvim/pull/336) pull request on mason-lspconfig