### PR TITLE
fix(biome): LSP-json-schema location, which is blocking any update to `biome`

### DIFF
--- a/packages/biome/package.yaml
+++ b/packages/biome/package.yaml
@@ -17,7 +17,7 @@ source:
   id: pkg:npm/@biomejs/biome@1.3.3
 
 schemas:
-  lsp: vscode:https://raw.githubusercontent.com/biomejs/biome/cli/v{{version}}/editors/vscode/package.json
+  lsp: vscode:https://raw.githubusercontent.com/biomejs/biome-vscode/main/package.json
 
 bin:
   biome: npm:biome

--- a/packages/biome/package.yaml
+++ b/packages/biome/package.yaml
@@ -14,7 +14,7 @@ categories:
   - Formatter
 
 source:
-  id: pkg:npm/@biomejs/biome@1.3.3
+  id: pkg:npm/@biomejs/biome@1.4.1
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/biomejs/biome-vscode/main/package.json


### PR DESCRIPTION
I noticed `biome` updates being stuck (https://github.com/mason-org/mason-registry/pull/3593). 

A closer look revealed the tests failed, cause the LSP-Json-schema could not be found. That json file has been moved to a new repository with this PR https://github.com/biomejs/biome/pull/819

---

This PR fixes the location of the LSP-Json-schema which is preventing mason from updating biome to 1.4+.

(I also bumped the biome version manually to 1.4.1 to speed things up, but feel free to leave out this commit, if the automated bumping is preferable for some reason.)
