### PR TITLE
chore/fix-easy-coding-standard

### DIFF
--- a/packages/easy-coding-standard/package.yaml
+++ b/packages/easy-coding-standard/package.yaml
@@ -11,7 +11,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:composer/symplify/easy-coding-standard@12.10.0
+  id: pkg:composer/symplify/easy-coding-standard@12.0.11
 
 bin:
   ecs: composer:ecs


### PR DESCRIPTION
Published version 12.10.0 of easy-coding-standard was [reverted](https://github.com/easy-coding-standard/easy-coding-standard/actions/runs/7069380276) (see [bump PR in registry](https://github.com/mason-org/mason-registry/pull/3651)).
There is no such version of this composer package anymore so installation fails.