### PR TITLE
bump(haskell-language-server): update to version 2.5.0.0

### DIFF
--- a/packages/haskell-language-server/package.yaml
+++ b/packages/haskell-language-server/package.yaml
@@ -11,7 +11,7 @@ categories:
 
 source:
   # renovate:datasource=github-releases
-  id: pkg:generic/haskell/haskell-language-server@2.4.0.0
+  id: pkg:generic/haskell/haskell-language-server@2.5.0.0
   build:
     - target: unix
       run: ghcup install hls "$VERSION" -i "$PWD"
@@ -20,9 +20,8 @@ source:
         VERSION: "{{version}}"
       bin:
         wrapper: bin/haskell-language-server-wrapper
-        server_9_0_2: bin/haskell-language-server-9.0.2
         server_9_2_8: bin/haskell-language-server-9.2.8
-        server_9_4_7: bin/haskell-language-server-9.4.7
+        server_9_4_8: bin/haskell-language-server-9.4.8
         server_9_6_3: bin/haskell-language-server-9.6.3
         server_9_8_1: bin/haskell-language-server-9.8.1
 
@@ -33,17 +32,15 @@ source:
         VERSION: "{{version}}"
       bin:
         wrapper: haskell-language-server-wrapper.exe
-        server_9_0_2: haskell-language-server-9.0.2.exe
         server_9_2_8: haskell-language-server-9.2.8.exe
-        server_9_4_7: haskell-language-server-9.4.7.exe
+        server_9_4_8: haskell-language-server-9.4.8.exe
         server_9_6_3: haskell-language-server-9.6.3.exe
         server_9_8_1: haskell-language-server-9.8.1.exe
 
 bin:
   haskell-language-server-wrapper: "{{source.build.bin.wrapper}}"
   # https://github.com/haskell/haskell-language-server/issues/3162
-  haskell-language-server-9.0.2: "{{ source.build.bin.server_9_0_2 | take_if_not(is_platform('darwin_arm64')) }}"
   haskell-language-server-9.2.8: "{{source.build.bin.server_9_2_8}}"
-  haskell-language-server-9.4.7: "{{source.build.bin.server_9_4_7}}"
+  haskell-language-server-9.4.8: "{{source.build.bin.server_9_4_8}}"
   haskell-language-server-9.6.3: "{{source.build.bin.server_9_6_3}}"
   haskell-language-server-9.8.1: "{{source.build.bin.server_9_8_1}}"


### PR DESCRIPTION
I updated the supported prebuilt GHC binaries.