### PR TITLE
feat: add termux-language-server

### DIFF
--- a/packages/termux-language-server/package.yaml
+++ b/packages/termux-language-server/package.yaml
@@ -1,0 +1,16 @@
+---
+name: termux-language-server
+description: A language server for some specific bash scripts.
+homepage: https://termux-language-server.readthedocs.io/en/latest/
+licenses:
+  - GPL-3.0
+languages:
+  - Bash
+categories:
+  - LSP
+
+source:
+  id: pkg:pypi/termux-language-server@0.0.22
+
+bin:
+  termux-language-server: pypi:termux-language-server


### PR DESCRIPTION
as per #3646, pkgbuild-language-server was wiped from the internet. The successor to that is termux-language-server. It adds several other file formats other then a PKGBUILD. This PR adds that LSP and I recommend deprecating or removing pkgbuild-language-server.