### PR TITLE
feat: Add htmlhint

### DIFF
--- a/packages/htmlhint/package.yaml
+++ b/packages/htmlhint/package.yaml
@@ -1,0 +1,15 @@
+---
+name: htmlhint
+description: The Static Code Analysis Tool for your HTML
+homepage: https://htmlhint.com
+licenses:
+  - MIT
+languages:
+  - HTML
+categories:
+  - Linter
+
+source:
+  id: pkg:npm/htmlhint@1.1.4
+bin:
+  htmlhint: npm:htmlhint


### PR DESCRIPTION
### Use Case
I am aware that the mason registry already has html linters such as markuplint, however I have found htmlhint to be the easiest to use. I think it would integrate really nicely with plugins like nvim-lint, as the binary file seems to work right out of the box.

