### PR TITLE
bump(staticcheck): update to v0.4.6

### DIFF
--- a/packages/staticcheck/package.yaml
+++ b/packages/staticcheck/package.yaml
@@ -10,7 +10,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:golang/honnef.co/go/tools/cmd/staticcheck@v0.4.6
+  id: pkg:golang/honnef.co/go/tools@v0.4.6#cmd/staticcheck
 
 bin:
   staticcheck: golang:staticcheck

--- a/packages/staticcheck/package.yaml
+++ b/packages/staticcheck/package.yaml
@@ -10,7 +10,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:golang/honnef.co/go/tools/cmd/staticcheck@2023.1.3
+  id: pkg:golang/honnef.co/go/tools/cmd/staticcheck@v0.4.6
 
 bin:
   staticcheck: golang:staticcheck


### PR DESCRIPTION
Currently used version is several months old and the latest is `v0.4.6`.

Package docs for reference: https://pkg.go.dev/honnef.co/go/tools@v0.4.6/cmd/staticcheck?tab=versions