### PR TITLE
feat: add dart language server

### DIFF
--- a/packages/dart/package.yaml
+++ b/packages/dart/package.yaml
@@ -1,0 +1,17 @@
+---
+name: dart
+description: |
+  Language server for Dart.
+homepage: https://github.com/dart-lang/sdk/blob/master/pkg/analysis_server/tool/lsp_spec
+licenses:
+  - BSD-3-Clause
+languages:
+  - Dart
+categories:
+  - LSP
+
+source:
+  id: pkg:github/dart-lang/sdk@3.2.3#sdk/bin
+
+bin:
+  dart: "dart"


### PR DESCRIPTION
## Why
Even though some nice Dart language server configs are present in [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/lua/lspconfig/server_configurations/dartls.lua), the language server itself has not yet been made available in the Mason's core package registry.

## What
Add it.