### PR TITLE
feat: add mdformat-gfm (#3888)

### DIFF
--- a/packages/mdformat-gfm/package.yaml
+++ b/packages/mdformat-gfm/package.yaml
@@ -1,0 +1,16 @@
+---
+name: mdformat-gfm
+description: Mdformat plugin for GitHub Flavored Markdown compatibility.
+homepage: https://github.com/hukkin/mdformat-gfm/
+licenses:
+  - MIT
+languages:
+  - Markdown
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/mdformat-gfm@0.3.5
+
+bin:
+  mdformat: pypi:mdformat


### PR DESCRIPTION
`mdformat-gfm` is an `mdformat` plugin that changes the target specification to GitHub Flavored Markdown (GFM).

Resolves: #3888