### PR TITLE
Install beancount-language-server without --locked

### DIFF
--- a/packages/beancount-language-server/package.yaml
+++ b/packages/beancount-language-server/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:cargo/beancount-language-server@1.3.1
+  id: pkg:cargo/beancount-language-server@1.3.1?locked=false
 
 bin:
   beancount-language-server: cargo:beancount-language-server


### PR DESCRIPTION
`cargo install --locked --force beancount-language-server` is broken due to broken dependencies in newer rust versions:

```
    Updating crates.io index
  Installing beancount-language-server v1.3.1
    Updating crates.io index
warning: package `bumpalo v3.12.1` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
warning: package `hermit-abi v0.3.1` in Cargo.lock is yanked in registry `crates-io`, consider running without --locked
    Updating crates.io index
   Compiling proc-macro2 v1.0.56
   Compiling libc v0.2.142
   Compiling unicode-ident v1.0.8
   Compiling quote v1.0.26
   Compiling cfg-if v1.0.0
   Compiling autocfg v1.1.0
   Compiling memchr v2.5.0
   Compiling serde_derive v1.0.160
   Compiling io-lifetimes v1.0.10
   Compiling once_cell v1.17.1
   Compiling serde v1.0.160
   Compiling rustix v0.37.17
   Compiling log v0.4.17
   Compiling cc v1.0.79
   Compiling bitflags v1.3.2
   Compiling aho-corasick v1.0.1
error[E0422]: cannot find struct, variant or union type `LineColumn` in crate `proc_macro`
   --> /Users/autrilla/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.56/src/wrapper.rs:475:33
    |
475 |                 let proc_macro::LineColumn { line, column } = s.start();
    |                                 ^^^^^^^^^^ not found in `proc_macro`
    |
help: consider importing this struct through its public re-export
    |
1   + use crate::LineColumn;
    |
help: if you import `LineColumn`, refer to it directly
    |
475 -                 let proc_macro::LineColumn { line, column } = s.start();
475 +                 let LineColumn { line, column } = s.start();
    |

error[E0422]: cannot find struct, variant or union type `LineColumn` in crate `proc_macro`
   --> /Users/autrilla/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.56/src/wrapper.rs:489:33
    |
489 |                 let proc_macro::LineColumn { line, column } = s.end();
    |                                 ^^^^^^^^^^ not found in `proc_macro`
    |
help: consider importing this struct through its public re-export
    |
1   + use crate::LineColumn;
    |
help: if you import `LineColumn`, refer to it directly
    |
489 -                 let proc_macro::LineColumn { line, column } = s.end();
489 +                 let LineColumn { line, column } = s.end();
    |

error[E0635]: unknown feature `proc_macro_span_shrink`
  --> /Users/autrilla/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.56/src/lib.rs:92:30
   |
92 |     feature(proc_macro_span, proc_macro_span_shrink)
   |                              ^^^^^^^^^^^^^^^^^^^^^^

Some errors have detailed explanations: E0422, E0635.
For more information about an error, try `rustc --explain E0422`.
error: could not compile `proc-macro2` (lib) due to 3 previous errors
warning: build failed, waiting for other jobs to finish...
error: failed to compile `beancount-language-server v1.3.1`, intermediate artifacts can be found at `/var/folders/yy/mf_ydq9j0lb4483nt872g27h0000gn/T/cargo-install2n7gza`.
To reuse those artifacts with a future compilation, set the environment variable `CARGO_TARGET_DIR` to that path.
```

vs without `--locked`:

```
    Updating crates.io index
  Installing beancount-language-server v1.3.1
    Updating crates.io index
   Compiling libc v0.2.151
   Compiling proc-macro2 v1.0.71
   Compiling unicode-ident v1.0.12
   Compiling autocfg v1.1.0
   Compiling cfg-if v1.0.0
   Compiling memchr v2.6.4
   Compiling once_cell v1.19.0
   Compiling serde v1.0.193
   Compiling regex-syntax v0.8.2
   Compiling itoa v1.0.10
   Compiling smallvec v1.11.2
   Compiling tinyvec_macros v0.1.1
   Compiling crossbeam-utils v0.8.17
   Compiling tinyvec v1.6.0
   Compiling aho-corasick v1.1.2
   Compiling tracing-core v0.1.32
   Compiling quote v1.0.33
   Compiling log v0.4.20
   Compiling syn v2.0.42
   Compiling cc v1.0.83
   Compiling utf8parse v0.2.1
   Compiling serde_json v1.0.108
   Compiling regex-syntax v0.6.29
   Compiling anstyle-parse v0.2.3
   Compiling unicode-normalization v0.1.22
   Compiling regex-automata v0.4.3
   Compiling num-traits v0.2.17
   Compiling lock_api v0.4.11
   Compiling colorchoice v1.0.0
   Compiling tree-sitter v0.20.10
   Compiling pin-project-lite v0.2.13
   Compiling powerfmt v0.2.0
   Compiling anstyle v1.0.4
   Compiling ryu v1.0.16
   Compiling regex-automata v0.1.10
   Compiling parking_lot_core v0.9.9
   Compiling lazy_static v1.4.0
   Compiling unicode-bidi v0.3.14
   Compiling percent-encoding v2.3.1
   Compiling thiserror v1.0.51
   Compiling option-ext v0.2.0
   Compiling anstyle-query v1.0.2
   Compiling anstream v0.6.5
   Compiling regex v1.10.2
   Compiling dirs-sys v0.4.1
   Compiling matchers v0.1.0
   Compiling idna v0.5.0
   Compiling form_urlencoded v1.2.1
   Compiling sharded-slab v0.1.7
   Compiling serde_derive v1.0.193
   Compiling tracing-attributes v0.1.27
   Compiling thiserror-impl v1.0.51
   Compiling deranged v0.3.10
   Compiling tree-sitter-beancount v2.0.0
   Compiling crossbeam-channel v0.5.9
   Compiling tracing v0.1.40
   Compiling tracing-log v0.2.0
   Compiling thread_local v1.1.7
   Compiling scopeguard v1.2.0
   Compiling time-core v0.1.2
   Compiling anyhow v1.0.76
   Compiling core-foundation-sys v0.8.6
   Compiling clap_lex v0.6.0
   Compiling strsim v0.10.0
   Compiling iana-time-zone v0.1.58
   Compiling clap_builder v4.4.11
   Compiling tracing-subscriber v0.3.18
   Compiling time v0.3.31
   Compiling serde_repr v0.1.17
   Compiling dirs v5.0.1
   Compiling num_cpus v1.16.0
   Compiling bitflags v1.3.2
   Compiling str_indices v0.4.3
   Compiling hashbrown v0.14.3
   Compiling ropey v1.6.1
   Compiling dashmap v5.5.3
   Compiling threadpool v1.8.1
   Compiling url v2.5.0
   Compiling shellexpand v3.1.0
   Compiling lsp-types v0.93.2
   Compiling lsp-server v0.6.0
   Compiling clap v4.4.11
   Compiling tracing-appender v0.2.3
   Compiling chrono v0.4.31
   Compiling linked-list v0.0.3
   Compiling bytes v1.5.0
   Compiling glob v0.3.1
   Compiling beancount-language-server v1.3.1
    Finished release [optimized] target(s) in 23.25s
   Replacing /Users/autrilla/.cargo/bin/beancount-language-server
    Replaced package `beancount-language-server v1.3.1` with `beancount-language-server v1.3.1` (executable `beancount-language-server`)
```