### PR TITLE
feat: add `pynvim`

### DIFF
--- a/packages/pynvim/package.yaml
+++ b/packages/pynvim/package.yaml
@@ -1,0 +1,13 @@
+---
+name: pynvim
+description: Python client and plugin host for Nvim
+homepage: https://github.com/neovim/pynvim
+licenses:
+  - Apache-2.0
+languages:
+  - Python
+categories:
+  - Runtime
+
+source:
+  id: pkg:pypi/pynvim@0.5.0


### PR DESCRIPTION
`pynvim` is a dependency for various plugins like [semshi](https://github.com/numirias/semshi) or [molten.nvim](https://github.com/benlubas/molten-nvim). Just like with `gh`, it makes bootstraping nvim on a new device much easier when it's available via Mason.

Installing it separately (not inside the same virtual environment as other python packages) works fine for some of those plugins.