### PR TITLE
Update elixir-ls to v0.18.1 with update to debugger

### DIFF
--- a/packages/elixir-ls/package.yaml
+++ b/packages/elixir-ls/package.yaml
@@ -13,18 +13,18 @@ categories:
   - DAP
 
 source:
-  id: pkg:github/elixir-lsp/elixir-ls@v0.17.10
+  id: pkg:github/elixir-lsp/elixir-ls@v0.18.1
   asset:
     - target: unix
       file: elixir-ls-{{version}}.zip
       bin:
         lsp: language_server.sh
-        dap: debugger.sh
+        dap: debug_adapter.sh
     - target: win
       file: elixir-ls-{{version}}.zip
       bin:
         lsp: language_server.bat
-        dap: debugger.bat
+        dap: debug_adapter.bat
 
   version_overrides:
     - constraint: semver:<=0.14.6


### PR DESCRIPTION
This is an attempt to reconcile the issues raised in #3910.

I have been unable to configure my mason installation in a way that uses my forked registry, so I'm unclear on whether any other change needs to be made to allow this to work.