### PR TITLE
feat: Add typescript to quick-lint-js

### DIFF
--- a/packages/quick-lint-js/package.yaml
+++ b/packages/quick-lint-js/package.yaml
@@ -8,6 +8,7 @@ licenses:
   - GPL-3.0-or-later
 languages:
   - JavaScript
+  - TypeScript
 categories:
   - LSP
   - Linter


### PR DESCRIPTION
Since version 3.0.0 quick-lint-js also supports typescript.