### PR TITLE
chore: use openvsx source for java-test and java-debug-adapter

### DIFF
--- a/packages/java-debug-adapter/package.yaml
+++ b/packages/java-debug-adapter/package.yaml
@@ -10,10 +10,10 @@ categories:
   - DAP
 
 source:
-  id: pkg:github/microsoft/vscode-java-debug@0.52.0
-  asset:
+  id: pkg:openvsx/vscjava/vscode-java-debug@0.55.0
+  download:
     file: vscjava.vscode-java-debug-{{version}}.vsix
 
 share:
   java-debug-adapter/: extension/server/
-  java-debug-adapter/com.microsoft.java.debug.plugin.jar: extension/server/com.microsoft.java.debug.plugin-0.47.0.jar
+  java-debug-adapter/com.microsoft.java.debug.plugin.jar: extension/server/com.microsoft.java.debug.plugin-0.50.0.jar

--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -21,9 +21,10 @@ categories:
   - DAP
 
 source:
-  id: pkg:github/microsoft/vscode-java-test@0.39.0
-  asset:
+  id: pkg:openvsx/vscjava/vscode-java-test@0.40.1
+  download:
     file: vscjava.vscode-java-test-{{version}}.vsix
 
 share:
   java-test/: extension/server/
+  java-test/com.microsoft.java.test.plugin.jar: extension/server/com.microsoft.java.test.plugin-{{version}}.jar


### PR DESCRIPTION
Closes https://github.com/mason-org/mason-registry/issues/3766.
Closes https://github.com/mason-org/mason-registry/issues/3036.