### PR TITLE
Decouple Erlang Language Server and Debugger

### DIFF
--- a/packages/erlang-debugger/package.yaml
+++ b/packages/erlang-debugger/package.yaml
@@ -1,0 +1,26 @@
+---
+name: erlang-debugger
+description: |
+  Step by step debugger for Erlang, powered by the Erlang/OTP interpreter and following the DAP protocol.
+homepage: https://erlang-ls.github.io/
+licenses:
+  - Apache-2.0
+languages:
+  - Erlang
+categories:
+  - DAP
+
+source:
+  id: pkg:github/erlang-ls/els_dap@0.1.3
+  build:
+    - target: win
+      run: |
+        rebar3 escriptize
+      els_dap: _build/dap/bin/els_dap.cmd
+    - target: unix
+      run: |
+        </dev/null rebar3 escriptize
+      els_dap: _build/dap/bin/els_dap
+
+bin:
+  els_dap: "{{source.build.els_dap}}"

--- a/packages/erlang-debugger/package.yaml
+++ b/packages/erlang-debugger/package.yaml
@@ -16,11 +16,11 @@ source:
     - target: win
       run: |
         rebar3 escriptize
-      els_dap: _build/dap/bin/els_dap.cmd
+      els_dap: _build/default/bin/els_dap.cmd
     - target: unix
       run: |
         </dev/null rebar3 escriptize
-      els_dap: _build/dap/bin/els_dap
+      els_dap: _build/default/bin/els_dap
 
 bin:
   els_dap: "{{source.build.els_dap}}"

--- a/packages/erlang-ls/package.yaml
+++ b/packages/erlang-ls/package.yaml
@@ -13,7 +13,7 @@ categories:
 
 source:
   # renovate:datasource=github-tags
-  id: pkg:github/erlang-ls/erlang_ls@0.48.1
+  id: pkg:github/erlang-ls/erlang_ls@0.49.0
   build:
     - target: win
       run: |

--- a/packages/erlang-ls/package.yaml
+++ b/packages/erlang-ls/package.yaml
@@ -9,7 +9,6 @@ licenses:
 languages:
   - Erlang
 categories:
-  - DAP
   - LSP
 
 source:
@@ -19,16 +18,11 @@ source:
     - target: win
       run: |
         rebar3 escriptize
-        rebar3 as dap escriptize
       erlang_ls: _build/default/bin/erlang_ls.cmd
-      els_dap: _build/dap/bin/els_dap.cmd
     - target: unix
       run: |
         </dev/null rebar3 escriptize
-        </dev/null rebar3 as dap escriptize
       erlang_ls: _build/default/bin/erlang_ls
-      els_dap: _build/dap/bin/els_dap
 
 bin:
   erlang_ls: "{{source.build.erlang_ls}}"
-  els_dap: "{{source.build.els_dap}}"


### PR DESCRIPTION
The debugger has been extracted from the Erlang LS repository, so it can be used in combination with other language servers (e.g. [ELP](https://github.com/mason-org/mason-registry/tree/main/packages/elp)). This PR (completely untested since I don't use Vim myself) adds a new package for the DAP debugger and removes the DAP parts from Erlang LS.