### PR TITLE
feat: add salt-lint

### DIFF
--- a/packages/salt-lint/package.yaml
+++ b/packages/salt-lint/package.yaml
@@ -1,0 +1,16 @@
+---
+name: salt-lint
+description: A command-line utility that checks for best practices in SaltStack.
+homepage: https://github.com/warpnet/salt-lint
+licenses:
+  - MIT
+languages:
+  - Salt
+categories:
+  - Linter
+
+source:
+  id: pkg:pypi/salt-lint@0.9.2
+
+bin:
+  salt-lint: pypi:salt-lint


### PR DESCRIPTION
PR to add the `salt-lint` linter for Salt / SaltStack.
https://github.com/warpnet/salt-lint

I'm not clear on how to test this yet, but it looks like opening a PR will trigger some CI tests.

Note: `salt-lint` is one of the linters supported by [null-ls](https://github.com/jose-elias-alvarez/null-ls.nvim) ( in [lua/null-ls/builtins/diagnostics/saltlint.lua](https://github.com/jose-elias-alvarez/null-ls.nvim/blob/main/lua/null-ls/builtins/diagnostics/saltlint.lua) ).  I'll also be submitting a PR to add support to [nvim-lint](https://github.com/mfussenegger/nvim-lint).

Thanks!