### PR TITLE
feat: sqls repo was moved. re-point it in mason-registry

### DIFF
--- a/packages/sqls/package.yaml
+++ b/packages/sqls/package.yaml
@@ -1,7 +1,7 @@
 ---
 name: sqls
 description: SQL language server written in Go.
-homepage: https://github.com/lighttiger2505/sqls
+homepage: https://github.com/sqls-server/sqls
 licenses:
   - MIT
 languages:
@@ -14,10 +14,3 @@ source:
 
 bin:
   sqls: golang:sqls
-
-# Fails to build on win_x64: https://github.com/mason-org/mason-registry/actions/runs/3809365442/jobs/6480780820
-ci_skip:
-  - win_arm
-  - win_arm64
-  - win_x64
-  - win_x86

--- a/packages/sqls/package.yaml
+++ b/packages/sqls/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:golang/github.com/lighttiger2505/sqls@v0.2.22
+  id: pkg:golang/github.com/sqls-server/sqls@v0.2.27
 
 bin:
   sqls: golang:sqls


### PR DESCRIPTION
The original sqls repo was archived, with future development moved into the github.com/sqls-server GitHub org. 

This PR:
* Updates mason-registry to use https://github.com/sqls-server/sqls instead of https://github.com/lighttiger2505/sqls.
* Version bumps `sqls` from `v0.2.22` to `v0.2.27`.