### PR TITLE
feat(stylua): add new linux_x64_musl target

### DIFF
--- a/packages/stylua/package.yaml
+++ b/packages/stylua/package.yaml
@@ -25,6 +25,9 @@ source:
     - target: linux_arm64_gnu
       file: stylua-linux-aarch64.zip
       bin: stylua
+    - target: linux_x64_musl
+      file: stylua-linux-x86_64-musl.zip
+      bin: stylua
     - target: win_x64
       file: stylua-win64.zip
       bin: stylua.exe

--- a/packages/stylua/package.yaml
+++ b/packages/stylua/package.yaml
@@ -25,12 +25,32 @@ source:
     - target: linux_arm64_gnu
       file: stylua-linux-aarch64.zip
       bin: stylua
-    - target: linux_x64_musl
+    - target: linux_x64
       file: stylua-linux-x86_64-musl.zip
       bin: stylua
     - target: win_x64
       file: stylua-win64.zip
       bin: stylua.exe
+
+  version_overrides:
+    - constraint: semver:<=v0.19.1
+      id: pkg:github/johnnymorganz/stylua@v0.19.1
+      asset:
+        - target: darwin_arm64
+          file: stylua-macos-aarch64.zip
+          bin: stylua
+        - target: darwin_x64
+          file: stylua-macos.zip
+          bin: stylua
+        - target: linux_x64_gnu
+          file: stylua-linux-x86_64.zip
+          bin: stylua
+        - target: linux_arm64_gnu
+          file: stylua-linux-aarch64.zip
+          bin: stylua
+        - target: win_x64
+          file: stylua-win64.zip
+          bin: stylua.exe
 
 bin:
   stylua: "{{source.asset.bin}}"


### PR DESCRIPTION
Hi and thank you for mason project

Thanks to @JohnnyMorganz availability from `stylua` [v0.20.0](https://github.com/JohnnyMorganz/StyLua/releases/tag/v0.20.0) (in mason registry already bumped here #4223) a new release artifact was added to support amd64 linux musl

This PR updates `stylua` package manifest in mason registry to incorporate this change

