### PR TITLE
feat: add hclfmt

### DIFF
--- a/packages/hclfmt/package.yaml
+++ b/packages/hclfmt/package.yaml
@@ -10,7 +10,7 @@ categories:
   - Formatter
 
 source:
-  id: pkg:golang/github.com/hashicorp/hcl/v2@2.19.1#cmd/hclfmt
+  id: pkg:golang/github.com/hashicorp/hcl/v2@v2.19.1#cmd/hclfmt
 
 bin:
   hclfmt: golang:hclfmt

--- a/packages/hclfmt/package.yaml
+++ b/packages/hclfmt/package.yaml
@@ -1,0 +1,16 @@
+---
+name: hclfmt
+description: A command to format HCL files
+homepage: https://github.com/hashicorp/hcl
+licenses:
+  - MPL-2.0
+languages:
+  - HCL
+categories:
+  - Formatter
+
+source:
+  id: pkg:golang/github.com/hashicorp/hcl/v2@2.19.1#cmd/hclfmt
+
+bin:
+  hclfmt: golang:hclfmt

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -67,6 +67,7 @@
         "GraphQL",
         "Groovy",
         "HAML",
+        "HCL",
         "HTML",
         "HTMX",
         "Handlebars",


### PR DESCRIPTION
A tool to format files written in the HashiCorp Configuration Language.
