### PR TITLE
fix(ltex): use platform-specific releases for win/mac

### DIFF
--- a/packages/ltex-ls/package.yaml
+++ b/packages/ltex-ls/package.yaml
@@ -15,16 +15,25 @@ categories:
 source:
   id: pkg:github/valentjn/ltex-ls@16.0.0
   asset:
-    - target: unix
-      file: ltex-ls-{{version}}.tar.gz
+    # The platform-specific releases bundle a java runtime engine, and are
+    # therefore preferable to avoid external dependencies (see #2837).
+    - target: darwin
+      file: ltex-ls-{{version}}-mac-x64.tar.gz
       bin:
         lsp: ltex-ls-{{version}}/bin/ltex-ls
         cli: ltex-ls-{{version}}/bin/ltex-cli
     - target: win
-      file: ltex-ls-{{version}}.tar.gz
+      file: ltex-ls-{{version}}-windows-x64.zip
       bin:
         lsp: ltex-ls-{{version}}/bin/ltex-ls.bat
         cli: ltex-ls-{{version}}/bin/ltex-cli.bat
+    # using platform-independent release to support linux arm64
+    # (see https://github.com/mason-org/mason-registry/pull/2837#pullrequestreview-1686482498)
+    - target: linux
+      file: ltex-ls-{{version}}.tar.gz
+      bin:
+        lsp: ltex-ls-{{version}}/bin/ltex-ls
+        cli: ltex-ls-{{version}}/bin/ltex-cli
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/valentjn/vscode-ltex/develop/package.json


### PR DESCRIPTION
The main intent is to remove the external dependency on a JRE, thus fixing: https://github.com/williamboman/mason.nvim/issues/1531 & https://github.com/valentjn/ltex-ls/issues/187

Implements #2837, but also for mac. Linux still uses the platform-independent release, [to ensure compatibility with arm64](https://github.com/mason-org/mason-registry/pull/2837#pullrequestreview-1686482498).