### PR TITLE
feat: add flowjs

### DIFF
--- a/packages/flowjs/package.yaml
+++ b/packages/flowjs/package.yaml
@@ -1,0 +1,18 @@
+---
+name: flowjs
+description: Static type checker for JavaScript
+homepage: https://github.com/facebook/flow
+licences:
+  - MIT
+languages:
+  - JavaScript
+categories:
+  - LSP
+
+source:
+  id: pkg:npm/flowjs/flow-bin@0.227.0
+  extra_packages:
+    - flow-remove-types
+
+bin:
+  flowjs: npm:flow-bin


### PR DESCRIPTION
WIP

This PR aims to add flowjs to Mason.

TO CHECK:
- global syntax
- how to use the project version of flow instead of the latest?
  - "${workspaceFolder}/node_modules/.bin/flow"

useful links:
- https://flow.org/en/docs/install/
- https://marketplace.visualstudio.com/items?itemName=flowtype.flow-for-vscode