### PR TITLE
Add zig to codelldb language list

### DIFF
--- a/packages/codelldb/package.yaml
+++ b/packages/codelldb/package.yaml
@@ -8,6 +8,7 @@ languages:
   - C
   - C++
   - Rust
+  - Zig
 categories:
   - DAP
 


### PR DESCRIPTION
The Codelldb debug adapter works with zig along with c, c++, and rust. This PR makes it explicit that codelldb works with zig