### PR TITLE
Add verible macOS binaries for both x86_64 and aarch64 Apple silicon

### DIFF
--- a/packages/verible/package.yaml
+++ b/packages/verible/package.yaml
@@ -54,6 +54,19 @@ source:
         project: verible-{{version}}-win64/verible-verilog-project.exe
         syntax: verible-{{version}}-win64/verible-verilog-syntax.exe
 
+    - target: [darwin_x64, darwin_arm64]
+      file: verible-{{version}}-macOS.tar.gz
+      bin:
+        diff: verible-{{version}}-macOS/bin/verible-verilog-diff
+        format: verible-{{version}}-macOS/bin/verible-verilog-format
+        kythe_extractor: verible-{{version}}-macOS/bin/verible-verilog-kythe-extractor
+        lint: verible-{{version}}-macOS/bin/verible-verilog-lint
+        ls: verible-{{version}}-macOS/bin/verible-verilog-ls
+        obfuscate: verible-{{version}}-macOS/bin/verible-verilog-obfuscate
+        preprocessor: verible-{{version}}-macOS/bin/verible-verilog-preprocessor
+        project: verible-{{version}}-macOS/bin/verible-verilog-project
+        syntax: verible-{{version}}-macOS/bin/verible-verilog-syntax
+
 bin:
   verible-verilog-diff: "{{source.asset.bin.diff}}"
   verible-verilog-format: "{{source.asset.bin.format}}"


### PR DESCRIPTION
Previously no support for macOS targets outside of [homebrew-verible](https://github.com/chipsalliance/homebrew-verible/tree/main). Tested binaries on M3 MacBook.