### PR TITLE
feat(sqlfluff): Add dbt-templater as extra package

### DIFF
--- a/packages/sqlfluff/package.yaml
+++ b/packages/sqlfluff/package.yaml
@@ -11,6 +11,8 @@ categories:
 
 source:
   id: pkg:pypi/sqlfluff@2.3.5
+  extra_packages:
+    - sqlfluff-templater-dbt
 
 bin:
   sqlfluff: pypi:sqlfluff


### PR DESCRIPTION
Sqlfluff is very popular to format dbt projects. The templater was recently extracted as an extra package. To regain the functionality to format dbt projects I've added the extension as an extra.