### PR TITLE
[feat]: added systemdlint linter

### DIFF
--- a/packages/systemdlint/package.yaml
+++ b/packages/systemdlint/package.yaml
@@ -1,0 +1,15 @@
+---
+name: systemdlint
+description: Systemd Unitfile Linter
+homepage: https://github.com/priv-kweihmann/systemdlint
+licenses:
+  - BSD-2-Clause
+languages: []
+categories:
+  - Linter
+
+source:
+  id: pkg:pypi/systemdlint@1.3.0
+
+bin:
+  systemdlint: pypi:systemdlint

--- a/packages/systemdlint/package.yaml
+++ b/packages/systemdlint/package.yaml
@@ -4,7 +4,8 @@ description: Systemd Unitfile Linter
 homepage: https://github.com/priv-kweihmann/systemdlint
 licenses:
   - BSD-2-Clause
-languages: []
+languages:
+  - systemd
 categories:
   - Linter
 

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -156,6 +156,7 @@
         "Starlark",
         "Stylelint",
         "Svelte",
+        "systemd",
         "SystemVerilog",
         "TOML",
         "Teal",


### PR DESCRIPTION
Added the `systemdlint` linter from: https://github.com/priv-kweihmann/systemdlint

The language supported here (in (n)vim terms anyway) is `systemd`, though I did not see it in the schema - do you want me to add it to the schema, or should I leave the `language` field empty?