### PR TITLE
feat: add harper-ls

### DIFF
--- a/packages/harper-ls/package.yaml
+++ b/packages/harper-ls/package.yaml
@@ -1,29 +1,28 @@
 ---
 name: harper-ls
 description: The Grammar Checker for Developers
-homepage: https://github.com/chilipepperhott/harper-ls
+homepage: https://github.com/elijah-potter/harper
 licenses:
   - Apache-2.0
 languages:
-  - Markdown,
-  - Rust,
-  - TypeScript,
-  - JavasCript,
-  - Python,
-  - Go,
-  - C,
-  - C++,
-  - Ruby,
-  - Swift,
-  - C#,
-  - TOML,
-  - Lua,
+  - Markdown
+  - Rust
+  - TypeScript
+  - JavaScript
+  - Python
+  - Go
+  - C
+  - C++
+  - Ruby
+  - C#
+  - TOML
+  - Lua
 categories:
   - LSP
 
 source:
   # renovate:versioning=loose
-  id: pkg:github/chilipepperhott/harper-ls@v0.7.3
+  id: pkg:github/elijah-potter/harper@v0.7.5
   asset:
     - target: linux_x64_gnu
       file: harper-ls-x86_64-unknown-linux-gnu.tar.gz

--- a/packages/harper-ls/package.yaml
+++ b/packages/harper-ls/package.yaml
@@ -1,0 +1,45 @@
+---
+name: harper-ls
+description: The Grammar Checker for Developers
+homepage: https://github.com/chilipepperhott/harper-ls
+licenses:
+  - Apache-2.0
+languages:
+  - Markdown,
+  - Rust,
+  - TypeScript,
+  - JavasCript,
+  - Python,
+  - Go,
+  - C,
+  - C++,
+  - Ruby,
+  - Swift,
+  - C#,
+  - TOML,
+  - Lua,
+categories:
+  - LSP
+
+source:
+  # renovate:versioning=loose
+  id: pkg:github/chilipepperhott/harper-ls@v0.7.3
+  asset:
+    - target: linux_x64_gnu
+      file: harper-ls-x86_64-unknown-linux-gnu.tar.gz
+      bin: harper-ls
+    - target: linux_arm64_gnu
+      file: harper-ls-aarch64-unknown-linux-gnu.tar.gz
+      bin: harper-ls
+    - target: darwin_x64
+      file: harper-ls-x86_64-apple-darwin.tar.gz
+      bin: harper-ls
+    - target: darwin_arm64
+      file: harper-ls-aarch64-apple-darwin.tar.gz
+      bin: harper-ls
+    - target: win_x64
+      file: harper-ls-x86_64-pc-windows-msvc.zip
+      bin: harper-ls.exe
+
+bin:
+  harper-ls: "{{source.asset.bin}}"

--- a/packages/harper-ls/package.yaml
+++ b/packages/harper-ls/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: harper-ls
-description: The Grammar Checker for Developers
+description: The Grammar Checker for Developers.
 homepage: https://github.com/elijah-potter/harper
 licenses:
   - Apache-2.0
@@ -21,7 +21,6 @@ categories:
   - LSP
 
 source:
-  # renovate:versioning=loose
   id: pkg:github/elijah-potter/harper@v0.7.5
   asset:
     - target: linux_x64_gnu
@@ -37,7 +36,7 @@ source:
       file: harper-ls-aarch64-apple-darwin.tar.gz
       bin: harper-ls
     - target: win_x64
-      file: harper-ls-x86_64-pc-windows-msvc.zip
+      file: harper-ls-x86_64-pc-windows-gnu.zip
       bin: harper-ls.exe
 
 bin:


### PR DESCRIPTION
Hey. I've been working on an English grammar checker called Harper.
I've recently gotten approval to add `harper-ls` (the LSP frontend) to `nvim-lspconfig`. However, I've found that many users find lack of Mason support a significant deterrent, so I'd like to add it to the registry.

I wrote the `package.yaml` in reference to `rust-analyzer/package.yaml`, and I believe it is spec-compliant.

You can find out more about it [here](https://github.com/chilipepperhott/harper).

Thank you for your consideration.