### PR TITLE
feat: add npm-groovy-lint

### DIFF
--- a/packages/npm-groovy-lint/package.yaml
+++ b/packages/npm-groovy-lint/package.yaml
@@ -1,0 +1,17 @@
+---
+name: npm-groovy-lint
+description: Lint, format and auto-fix your Groovy / Jenkinsfile / Gradle files using command line.
+homepage: https://github.com/nvuillam/npm-groovy-lint
+licenses:
+  - GPL-3.0
+languages:
+  - Groovy
+categories:
+  - Linter
+  - Formatter
+
+source:
+  id: pkg:npm/npm-groovy-lint@14.2.2
+
+bin:
+  npm-groovy-lint: npm:npm-groovy-lint

--- a/packages/npm-groovy-lint/package.yaml
+++ b/packages/npm-groovy-lint/package.yaml
@@ -3,7 +3,7 @@ name: npm-groovy-lint
 description: Lint, format and auto-fix your Groovy / Jenkinsfile / Gradle files using command line.
 homepage: https://github.com/nvuillam/npm-groovy-lint
 licenses:
-  - GPL-3.0
+  - GPL-3.0-only
 languages:
   - Groovy
 categories:


### PR DESCRIPTION
Hey i've seen that there is a help wanted label in the mason repo regarding the williamboman/mason.nvim#760 issue, and i also happen to use the npm-groovy-lint for formatting my Jenkinsfile

I have made the package.yaml by referencing the yaml-language-server package as it is also a npm package and by using the schema provided i believe the package.yaml already comply, but feel free to point out if there is something wrong with the package.yaml as this is my first time contributing to this repo.

Thankyou. 