### PR TITLE
Added deno arm64 target

### DIFF
--- a/packages/deno/package.yaml
+++ b/packages/deno/package.yaml
@@ -19,6 +19,9 @@ source:
     - target: darwin_arm64
       file: deno-aarch64-apple-darwin.zip
       bin: deno
+    - target: linux_arm64_gnu
+      file: deno-aarch64-unknown-linux-gnu.zip
+      bin: deno
     - target: darwin_x64
       file: deno-x86_64-apple-darwin.zip
       bin: deno


### PR DESCRIPTION
Deno v1.40.3 and above now supports aarch64 on Linux