### PR TITLE
categorise ruff as a linter and formatter

### DIFF
--- a/packages/ruff/package.yaml
+++ b/packages/ruff/package.yaml
@@ -8,6 +8,7 @@ languages:
   - Python
 categories:
   - Linter
+  - Formatter
 
 source:
   id: pkg:pypi/ruff@0.3.0


### PR DESCRIPTION
ruff is also a formatter and should appear under both the Linter and Formatter category.

ref: https://docs.astral.sh/ruff/formatter/