### PR TITLE
feat() add @vue/typescript-plugin to volar

### DIFF
--- a/packages/vue-language-server/package.yaml
+++ b/packages/vue-language-server/package.yaml
@@ -13,6 +13,7 @@ source:
   id: pkg:npm/%40vue/language-server@2.0.6
   extra_packages:
     - typescript
+    - /%40vue/typescript-plugin@{{ version }}
 
 bin:
   vue-language-server: npm:vue-language-server


### PR DESCRIPTION
Since version 2.0.0 of the @vue/language-server, @vue/typescript-plugin is required for proper TS support.

I'm not sure if it work that way, or if there is a preffered way to do this. Some guidance is welcome!

See https://github.com/vuejs/language-tools/issues/3925 for the issue in @vue/language-server repo.

Version of the @vue/language-server and @vue/typescript-plugin must match and it's a bit of a pain to maintain both version manually.