### PR TITLE
feat: add support for Nushell

### DIFF
--- a/packages/nushell/package.yaml
+++ b/packages/nushell/package.yaml
@@ -1,0 +1,17 @@
+name: string
+description: string
+homepage: URL
+licenses: SPDXLicense[]
+languages: string[]
+categories: Category[]
+
+source:
+    id: string
+    [key: string]: any
+
+bin?:
+    [executable: string]: string
+share?:
+    [share_location: string]: string
+opt?:
+    [opt_location: string]: string

--- a/packages/nushell/package.yaml
+++ b/packages/nushell/package.yaml
@@ -1,17 +1,15 @@
-name: string
-description: string
-homepage: URL
-licenses: SPDXLicense[]
-languages: string[]
-categories: Category[]
+name: nushell
+description: A new type of shell
+homepage: https://www.nushell.sh/
+licenses:
+  - MIT
+languages:
+  - Nushell
+categories:
+  - LSP
 
 source:
-    id: string
-    [key: string]: any
+  id: pkg:github/nushell/nushell@0.91.0
 
-bin?:
-    [executable: string]: string
-share?:
-    [share_location: string]: string
-opt?:
-    [opt_location: string]: string
+bin:
+  nu: nu


### PR DESCRIPTION
hello there :wave: 

this is an attempt at adding support for [Nushell](https://github.com/nushell/nushell)!

the goal is to replace the following snippet of Neovim config with a simpler Mason install:
```lua
local lspconfig = require'lspconfig'
lspconfig.nushell.setup{
  cmd = { "nu", "--lsp" },
  filetypes = { "nu" },
  root_dir = function(fname)
      local git_root = lspconfig.util.find_git_ancestor(fname)
      if git_root then
          return git_root
      else
          return vim.fn.fnamemodify(fname, ":p:h")  -- get the parent directory of the file
      end
  end,
  capabilities = capabilities,
  on_attach = on_attach,
}
```

i tried to follow the `CONTRIBUTING.md` document, hope i'm not too far from what's expected :innocent: 

## details
- `$.source.id` is set to `pkg:github/nushell/nushell@0.91.0` because the repo is https://github.com/nushell/nushell and the latest version is `0.91.0`
- `$.bin.nu` is set to `nu` because there is the `nu` binary directly at the root of the archive of the package

## questions
i have a question though, how can we tell Mason to run `nu --lsp` instead of just `nu` when running the LSP server?
the thing is that the LSP for Nushell is embedded in the Nushell binary itself, i.e.
- `nu` is the shell itself
- `nu --lsp` runs the LSP server