### PR TITLE
feat: add ocamlearlybird

### DIFF
--- a/packages/ocamlearlybird/package.yaml
+++ b/packages/ocamlearlybird/package.yaml
@@ -1,0 +1,16 @@
+---
+name: ocamlearlybird
+description: OCaml debug adapter.
+homepage: https://github.com/hackwaly/ocamlearlybird
+licenses:
+  - MIT
+languages:
+  - OCaml
+categories:
+  - DAP
+
+source:
+  id: pkg:opam/earlybird@1.3.2
+
+bin:
+  ocamlearlybird: opam:ocamlearlybird


### PR DESCRIPTION
Adds Ocaml DAP `ocamlearlybird` https://github.com/hackwaly/ocamlearlybird. Release https://github.com/hackwaly/ocamlearlybird/releases/tag/1.3.2.

Added setup description to [nvim-dap](https://github.com/mfussenegger/nvim-dap/wiki/Debug-Adapter-installation#ocaml-earlybird).