### PR TITLE
feat(php_codesniffer): update repository location

### DIFF
--- a/packages/phpcbf/package.yaml
+++ b/packages/phpcbf/package.yaml
@@ -1,7 +1,7 @@
 ---
 name: phpcbf
 description: phpcbf automatically corrects coding standard violations that would be detected by phpcs.
-homepage: https://github.com/squizlabs/PHP_CodeSniffer
+homepage: https://github.com/PHPCSStandards/PHP_CodeSniffer
 licenses:
   - BSD-3-Clause
 languages:
@@ -10,7 +10,7 @@ categories:
   - Formatter
 
 source:
-  id: pkg:github/squizlabs/PHP_CodeSniffer@3.7.2
+  id: pkg:github/PHPCSStandards/PHP_CodeSniffer@3.7.2
   asset:
     file: phpcbf.phar
 

--- a/packages/phpcs/package.yaml
+++ b/packages/phpcs/package.yaml
@@ -1,7 +1,7 @@
 ---
 name: phpcs
 description: phpcs tokenizes PHP, JavaScript and CSS files to detect violations of a defined standard.
-homepage: https://github.com/squizlabs/PHP_CodeSniffer
+homepage: https://github.com/PHPCSStandards/PHP_CodeSniffer
 licenses:
   - BSD-3-Clause
 languages:
@@ -10,7 +10,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:github/squizlabs/PHP_CodeSniffer@3.7.2
+  id: pkg:github/PHPCSStandards/PHP_CodeSniffer@3.7.2
   asset:
     file: phpcs.phar
 


### PR DESCRIPTION
PHP_CodeSniffer development is abandoned in squizlabs repository (https://github.com/squizlabs/PHP_CodeSniffer), but continues under PHPCSStandards repository (https://github.com/PHPCSStandards/PHP_CodeSniffer).

This PR only updates the source and doesn't update the version, squizlabs is still on version 3.7.2 but the updated repository is on version 3.9.0. I chose to not update the version to minimize the possible impact of this PR.