### PR TITLE
Add spring boot language server schema package

### DIFF
--- a/packages/springboot-language-server/package.yaml
+++ b/packages/springboot-language-server/package.yaml
@@ -1,0 +1,21 @@
+---
+name: springboot-language-server
+description: SpringBoot Language Server.
+homepage: https://github.com/spring-projects/sts4
+licenses:
+  - EPL-1.0
+languages:
+  - XML
+  - YAML
+  - Java
+categories:
+  - Linter
+
+source:
+  id: pkg:github/spring-projects/sts4/vscode-spring-boot@4.22.0
+  asset:
+    file: vscode-spring-boot-1.53.0-RC.3.vsix
+
+share:
+  springboot-extensions/: extension/jars/
+  springboot-server/: extension/language-server/


### PR DESCRIPTION
Initial attempt at adding the resources for the spring boot language server. The language server itself is presented as an exploded jar, so it does really have a jar binary, in other words it has to be started with `java -cp <classpath> <mainclass>`. More information can be found here.

https://github.com/spring-projects/sts4/issues/1128#issuecomment-1872665406
https://github.com/spring-projects/sts4/blob/8bf29f4b9126135e4d5eb4ab7c02136f4ef3c9ba/vscode-extensions/commons-vscode/src/launch-util.ts#L231w
https://github.com/emacs-lsp/lsp-java/blob/master/lsp-java-boot.el#L128
