### PR TITLE
feat: add basedpyright

### DIFF
--- a/packages/basedpyright/package.yaml
+++ b/packages/basedpyright/package.yaml
@@ -1,0 +1,20 @@
+---
+name: basedpyright
+description: Fork of the Pyright static type checker for Python, which adds extra Pylance features.
+homepage: https://detachhead.github.io/basedpyright
+licenses:
+  - MIT
+languages:
+  - Python
+categories:
+  - LSP
+
+source:
+  id: pkg:pypi/basedpyright@1.5.0
+
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/DetachHead/basedpyright/{{version}}/packages/vscode-pyright/package.json
+
+bin:
+  basedpyright: pypi:basedpyright
+  basedpyright-langserver: pypi:basedpyright-langserver

--- a/packages/basedpyright/package.yaml
+++ b/packages/basedpyright/package.yaml
@@ -1,6 +1,6 @@
 ---
 name: basedpyright
-description: Fork of the Pyright static type checker for Python, which adds extra Pylance features.
+description: Fork of the Pyright static type checker for Python, with extra Pylance features.
 homepage: https://detachhead.github.io/basedpyright
 licenses:
   - MIT

--- a/packages/basedpyright/package.yaml
+++ b/packages/basedpyright/package.yaml
@@ -13,7 +13,7 @@ source:
   id: pkg:pypi/basedpyright@1.5.0
 
 schemas:
-  lsp: vscode:https://raw.githubusercontent.com/DetachHead/basedpyright/{{version}}/packages/vscode-pyright/package.json
+  lsp: vscode:https://raw.githubusercontent.com/DetachHead/basedpyright/v{{version}}/packages/vscode-pyright/package.json
 
 bin:
   basedpyright: pypi:basedpyright


### PR DESCRIPTION
BasedPyright is a fork of the pyright project aiming to implement further features not included in the original project.

Those features include functionality deliberately left out of Pyright in favor of Microsoft's closed source project Pylance.