### PR TITLE
Working on adding registry entry for VHDL_LS 

### DIFF
--- a/packages/vhdl_ls/package.yaml
+++ b/packages/vhdl_ls/package.yaml
@@ -17,6 +17,10 @@ source:
       bin: vhdl_ls
     - target: linux_x64_gnu
       file: vhdl_ls-x86_64-unknown-linux-gnu.zip
+      bin: vhdl_ls
+    - target: linux_x64_musl
+      file: vhdl_ls-x86_64-unknown-linux-musl.zip
+      bin: vhdl_ls
     - target: win_x64
       file: vhdl_ls-x86_64-pc-windows-msvc.zip
       bin: vhdl_ls.exe

--- a/packages/vhdl_ls/package.yaml
+++ b/packages/vhdl_ls/package.yaml
@@ -1,0 +1,26 @@
+---
+name: vhdl_ls
+description: |
+  VHDL Language Server, written in rust
+homepage: https://github.com/VHDL-LS/rust_hdl
+licenses:
+  - MPL-2.0
+languages:
+  - VHDL
+categories:
+  - LSP
+source:
+  id: pkg:github/VHDL-LS/rust_hdl@v0.78.1
+  asset:
+    - target: darwin_arm64
+      file: vhdl_ls-aarch64-apple-darwin.zip
+      bin: vhdl_ls
+    - target: linux_x64_gnu
+      file: vhdl_ls-x86_64-unknown-linux-gnu.zip
+    - target: win_x64
+      file: vhdl_ls-x86_64-pc-windows-msvc.zip
+      bin: vhdl_ls.exe
+share:
+  vhdl_libraries: vhdl_libraries
+bin:
+  vhdl_ls: "{{source.asset.bin}}"


### PR DESCRIPTION
## Describe your changes
Fixes #3615 by adding a registry entry for [`vhdl_ls`](https://github.com/VHDL-LS/rust_hdl). I am open to changing the name of the actual entry in `:Mason`, since I put `rust_hdl` since that's the repo name, however the binary name is `vhdl_ls`. I would like feedback on this.

## Issue ticket number and link
#3615 

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

In order to test this, I opened up an example project I had for VHDL, after uninstalling my original overall installation. This worked

