### PR TITLE
Adds ginko registry entry

### DIFF
--- a/packages/ginko_ls/package.yaml
+++ b/packages/ginko_ls/package.yaml
@@ -17,7 +17,7 @@ source:
     - target: darwin_arm64
       file: ginko_ls-aarch64-apple-darwin.zip
       bin: ginko_ls-aarch64-apple-darwin/bin/ginko_ls
-    - target: linux_x64
+    - target: linux_x64_gnu
       file: ginko_ls-x86_64-unknown-linux-gnu.zip
       bin: ginko_ls-x86_64-unknown-linux-gnu/bin/ginko_ls
     - target: win_x64

--- a/packages/ginko_ls/package.yaml
+++ b/packages/ginko_ls/package.yaml
@@ -3,7 +3,7 @@ name: ginko_ls
 description: |
   ginko_ls is meant to be a feature-complete language server for device-trees. Language servers can be used in many
   editors, such as Visual Studio Code, Emacs or Vim
-homepage: https://github.com/Schottkyc137
+homepage: https://github.com/Schottkyc137/ginko
 licenses:
   - MIT
 languages:

--- a/packages/ginko_ls/package.yaml
+++ b/packages/ginko_ls/package.yaml
@@ -1,0 +1,28 @@
+---
+name: ginko_ls
+description: |
+  ginko_ls is meant to be a feature-complete language server for device-trees. Language servers can be used in many
+  editors, such as Visual Studio Code, Emacs or Vim
+homepage: https://github.com/Schottkyc137
+licenses:
+  - MIT
+languages:
+  - DTS
+categories:
+  - LSP
+
+source:
+  id: pkg:github/Schottkyc137/ginko@v0.0.4
+  asset:
+    - target: darwin_arm64
+      file: ginko_ls-aarch64-apple-darwin.zip
+      bin: ginko_ls-aarch64-apple-darwin/bin/ginko_ls
+    - target: linux_x64
+      file: ginko_ls-x86_64-unknown-linux-gnu.zip
+      bin: ginko_ls-x86_64-unknown-linux-gnu/bin/ginko_ls
+    - target: win_x64
+      file: ginko_ls-x86_64-pc-windows-msvc.zip
+      bin: ginko_ls-x86_64-pc-windows-msvc/bin/ginko_ls.exe
+
+bin:
+  ginko_ls: "{{source.asset.bin}}"

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -48,6 +48,7 @@
         "Django",
         "Docker",
         "Drools",
+        "DTS",
         "Elixir",
         "Elm",
         "Ember",


### PR DESCRIPTION
## Describe your changes
Adds a registry entry for [`ginko_ls`](https://github.com/Schottkyc137/ginko), which is a Device Tree (DTS) Parser and language server. It's very early stages right now, but it's functional. I will also be working on a PR in `nvim-lspconfig` to have a built in configuration for this, as I am currently using a custom defined one.

## Issue ticket number and link


## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
I tested with the example that the Ginko readme provides. 
```dts
/dts-v1/;

/ {
    pic@10000000 {
        phandle = <1>;
        interrupt-controller;
        reg = <0x10000000 0x100>;
    }
};
```

In order to configure the LSP, I added this to my nvim configs
```lua
    if not configs.ginko_ls then
        configs.ginko_ls = {
            default_config = {
                cmd = { "ginko_ls" };
                filetypes = { "dts" };
                root_dir = function (_)
                    return vim.fs.dirname(vim.fs.find({ '.git' }, { upward = true })[1]);
                end,
                settings = {};
            };
        }
    end
```
Which showed an error after the `}` for `pic@10000000` node.
## Screenshots
![image](https://github.com/mason-org/mason-registry/assets/19225089/6cd92641-9deb-4a49-af32-f0748a06788b)
Screenshot showing that it is appropriately using the `ginko_ls` binary in the mason path.
