### PR TITLE
bump(tectonic): update version to 0.15.0

### DIFF
--- a/packages/tectonic/package.yaml
+++ b/packages/tectonic/package.yaml
@@ -10,7 +10,7 @@ categories:
   - Compiler
 
 source:
-  id: pkg:github/tectonic-typesetting/tectonic@tectonic%400.14.1
+  id: pkg:github/tectonic-typesetting/tectonic@tectonic%400.15.0
   asset:
     - target: darwin_x64
       file: tectonic-{{ version || strip_prefix "tectonic@" }}-x86_64-apple-darwin.tar.gz


### PR DESCRIPTION
## Describe your changes
I just updated tectonic to the latest release. I'm not sure why the renovate bot isn't picking it up, it seems like the last bump was done manually too.

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->