### PR TITLE
add LSP category to ruff

### DIFF
--- a/packages/ruff/package.yaml
+++ b/packages/ruff/package.yaml
@@ -9,6 +9,7 @@ languages:
 categories:
   - Linter
   - Formatter
+  - LSP
 
 source:
   id: pkg:pypi/ruff@0.3.4


### PR DESCRIPTION
## Describe your changes
ruff now has experimental LSP support and should appear under this category.

- https://github.com/astral-sh/ruff/pull/10158
- https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#ruff

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.


