### PR TITLE
feat(pylyzer): use github releases instead of `cargo`

### DIFF
--- a/packages/pylyzer/package.yaml
+++ b/packages/pylyzer/package.yaml
@@ -14,16 +14,22 @@ source:
   asset:
     - target: darwin_arm64
       file: pylyzer-aarch64-apple-darwin.tar.gz
+      bin: pylyzer
     - target: darwin_x64
       file: pylyzer-x86_64-apple-darwin.tar.gz
+      bin: pylyzer
     - target: linux_armv7l
       file: pylyzer-armv7-unknown-linux-gnueabihf.tar.gz
+      bin: pylyzer
     - target: linux_x64
       file: pylyzer-x86_64-unknown-linux-gnu.tar.gz
+      bin: pylyzer
     - target: linux_arm64
       file: pylyzer-aarch64-unknown-linux-gnu.tar.gz
+      bin: pylyzer
     - target: win_x64
       file: pylyzer-x86_64-pc-windows-msvc.zip
+      bin: pylyzer.exe
 
 bin:
-  pylyzer: pylyzer
+  pylyzer: "{{source.asset.bin}}"

--- a/packages/pylyzer/package.yaml
+++ b/packages/pylyzer/package.yaml
@@ -10,7 +10,20 @@ categories:
   - LSP
 
 source:
-  id: pkg:cargo/pylyzer@0.0.51
+  id: pkg:github/mtshiba/pylyzer@v0.0.51
+  asset:
+    - target: darwin_arm64
+      file: pylyzer-aarch64-apple-darwin.tar.gz
+    - target: darwin_x64
+      file: pylyzer-x86_64-apple-darwin.tar.gz
+    - target: linux_armv7l
+      file: pylyzer-armv7-unknown-linux-gnueabihf.tar.gz
+    - target: linux_x64
+      file: pylyzer-x86_64-unknown-linux-gnu.tar.gz
+    - target: linux_arm64
+      file: pylyzer-aarch64-unknown-linux-gnu.tar.gz
+    - target: win_x64
+      file: pylyzer-x86_64-pc-windows-msvc.zip
 
 bin:
-  pylyzer: cargo:pylyzer
+  pylyzer: pylyzer


### PR DESCRIPTION
## Describe your changes
Use github releases instead of `cargo`. This has the advantage that users do not require the rust toolchain to install this package.

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
