### PR TITLE
Update Jdtls to 1.34

### DIFF
--- a/packages/jdtls/package.yaml
+++ b/packages/jdtls/package.yaml
@@ -11,7 +11,7 @@ categories:
 
 source:
   # renovate:datasource=github-tags
-  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.33.0
+  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.34.0
   download:
     - target: [darwin_x64, darwin_arm64]
       files:

--- a/packages/jdtls/package.yaml
+++ b/packages/jdtls/package.yaml
@@ -15,17 +15,17 @@ source:
   download:
     - target: [darwin_x64, darwin_arm64]
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202402151717.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202404031240.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_mac/
     - target: linux
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202402151717.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202404031240.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_linux/
     - target: win
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202402151717.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202404031240.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_win/
 

--- a/packages/jdtls/package.yaml
+++ b/packages/jdtls/package.yaml
@@ -38,5 +38,5 @@ bin:
 share:
   jdtls/lombok.jar: lombok.jar
   jdtls/plugins/: plugins/
-  jdtls/plugins/org.eclipse.equinox.launcher.jar: plugins/org.eclipse.equinox.launcher_1.6.700.v20231214-2017.jar
+  jdtls/plugins/org.eclipse.equinox.launcher.jar: plugins/org.eclipse.equinox.launcher_1.6.800.v20240304-1850.jar
   jdtls/config/: "{{source.download.config}}"


### PR DESCRIPTION
## Describe your changes
I noticed that the automatic version bumping did not correctly update the URL for the archive so I made the small adjustment by hand.

[Source](https://download.eclipse.org/jdtls/milestones/1.34.0/latest.txt)

If accepted then this [PR](https://github.com/mason-org/mason-registry/pull/5225) could be closed.

## Issue ticket number and link

## Checklist before requesting a review

I have not done any of those since it's a simple version bump and there are GH Actions in place.

- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.

## Screenshots
