### PR TITLE
chore(renovate): ignore rescript-lsp

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -103,5 +103,8 @@
             matchDepNames: ["tectonic"],
             allowedVersions: "^tectonic@"
         }
+    ],
+    "ignoreDeps": [
+        "rescript-lsp"
     ]
 }


### PR DESCRIPTION
This package has been deprecated and is replaced by rescript-language-server.
