### PR TITLE
docs: update ansible-language-server homepage url

### DIFF
--- a/packages/ansible-language-server/package.yaml
+++ b/packages/ansible-language-server/package.yaml
@@ -1,7 +1,7 @@
 ---
 name: ansible-language-server
 description: Ansible Language Server.
-homepage: https://github.com/ansible/ansible-language-server
+homepage: https://github.com/ansible/vscode-ansible
 licenses:
   - MIT
 languages:


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Updating the homepage for the `ansible-language-server` to the latest URL, as the currently stated URL points to an archived repository (whose repo description also now points to the latest URL as introduced by this change).
This can be further verified at the package's registry page here: https://www.npmjs.com/package/@ansible/ansible-language-server
## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
