### PR TITLE
Revert ansible-language-server to working version 1.2.1

### DIFF
--- a/packages/ansible-language-server/package.yaml
+++ b/packages/ansible-language-server/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:npm/%40ansible/ansible-language-server@1.2.2
+  id: pkg:npm/%40ansible/ansible-language-server@1.2.1
 
 bin:
   ansible-language-server: npm:ansible-language-server

--- a/renovate.json5
+++ b/renovate.json5
@@ -102,6 +102,10 @@
         {
             matchDepNames: ["tectonic"],
             allowedVersions: "^tectonic%40"
+        },
+        {
+            matchDepNames: ["ansible-language-server"],
+            allowedVersions: "!/1\\.2\\.2/"
         }
     ],
     "ignoreDeps": [


### PR DESCRIPTION
## Describe your changes
Redhat devs are working on incorporating [ansible-language-server](https://github.com/ansible/ansible-language-server) in [vscode-ansible](https://github.com/ansible/vscode-ansible) repo.
Latest version is broken. Reverting it while they fix the issue would allow us to have a working version available through mason without too much config.

## Issue ticket number and link
https://github.com/ansible/vscode-ansible/issues/1266

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
