### PR TITLE
feat: add crlfmt configuration

### DIFF
--- a/packages/crlfmt/package.yaml
+++ b/packages/crlfmt/package.yaml
@@ -1,0 +1,17 @@
+---
+name: crlfmt
+description: Formatter for Go code that enforces the CockroachDB Style Guide.
+homepage: https://github.com/cockroachdb/crlfmt
+licenses:
+  - Apache-2.0
+  - BSD-3-Clause
+languages:
+  - Go
+categories:
+  - Formatter
+
+source:
+  id: pkg:golang/github.com/cockroachdb/crlfmt@v0.0.0-20230505164321-461e8663b4b4
+
+bin:
+  crlfmt: golang:crlfmt


### PR DESCRIPTION
## Describe your changes
Adding the `crlfmt` formatter, a `gofmt`-style formatter for Go code that enforces the [CockroachDB Style Guide](https://wiki.crdb.io/wiki/spaces/CRDB/pages/181371303/Go+coding+guidelines).

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

## Screenshots
<!-- Leave empty if not applicable -->
<img width="1077" alt="image" src="https://github.com/mason-org/mason-registry/assets/42865/e8bcd3ba-46bb-4ab7-bc67-1d37649cc2bc">
