### PR TITLE
bump-fix(zls): update to v0.12.0

### DIFF
--- a/packages/zls/package.yaml
+++ b/packages/zls/package.yaml
@@ -10,31 +10,56 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/zigtools/zls@0.11.0
+  id: pkg:github/zigtools/zls@0.12.0
   asset:
     - target: darwin_arm64
-      file: zls-aarch64-macos.tar.gz
-      bin: bin/zls
+      file: zls-aarch64-macos.tar.xz
+      bin: zls
     - target: darwin_x64
-      file: zls-x86_64-macos.tar.gz
-      bin: bin/zls
+      file: zls-x86_64-macos.tar.xz
+      bin: zls
     - target: linux_arm64
-      file: zls-aarch64-linux.tar.gz
-      bin: bin/zls
+      file: zls-aarch64-linux.tar.xz
+      bin: zls
     - target: linux_x64
-      file: zls-x86_64-linux.tar.gz
-      bin: bin/zls
+      file: zls-x86_64-linux.tar.xz
+      bin: zls
     - target: linux_x86
-      file: zls-x86-linux.tar.gz
-      bin: bin/zls
+      file: zls-x86-linux.tar.xz
+      bin: zls
     - target: win_x86
       file: zls-x86-windows.zip
-      bin: bin/zls.exe
+      bin: zls.exe
     - target: win_x64
       file: zls-x86_64-windows.zip
-      bin: bin/zls.exe
+      bin: zls.exe
 
   version_overrides:
+    - constraint: semver:<=0.11.0
+      id: pkg:github/zigtools/zls@0.11.0
+      asset:
+        - target: darwin_arm64
+          file: zls-aarch64-macos.tar.gz
+          bin: bin/zls
+        - target: darwin_x64
+          file: zls-x86_64-macos.tar.gz
+          bin: bin/zls
+        - target: linux_arm64
+          file: zls-aarch64-linux.tar.gz
+          bin: bin/zls
+        - target: linux_x64
+          file: zls-x86_64-linux.tar.gz
+          bin: bin/zls
+        - target: linux_x86
+          file: zls-x86-linux.tar.gz
+          bin: bin/zls
+        - target: win_x86
+          file: zls-x86-windows.zip
+          bin: bin/zls.exe
+        - target: win_x64
+          file: zls-x86_64-windows.zip
+          bin: bin/zls.exe
+
     - constraint: semver:<=0.10.0
       id: pkg:github/zigtools/zls@0.10.0
       asset:


### PR DESCRIPTION
## Describe your changes
Updated version to 0.12.0

- looks like the zls binaries are no longer in a bin subdir but at the root of the archive.
- Also added an overrride for 0.11.0
- archive format for linux and macos has changed to `tar.xz`

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
