### PR TITLE
feat(lua-language-server): restore linux_arm64_gnu target for v3.9.0

### DIFF
--- a/packages/lua-language-server/package.yaml
+++ b/packages/lua-language-server/package.yaml
@@ -18,6 +18,9 @@ source:
     - target: darwin_x64
       file: lua-language-server-{{version}}-darwin-x64.tar.gz:libexec/
       bin: exec:libexec/bin/lua-language-server
+    - target: linux_arm64_gnu
+      file: lua-language-server-{{version}}-linux-arm64.tar.gz:libexec/
+      bin: exec:libexec/bin/lua-language-server
     - target: linux_x64_gnu
       file: lua-language-server-{{version}}-linux-x64.tar.gz:libexec/
       bin: exec:libexec/bin/lua-language-server
@@ -29,6 +32,24 @@ source:
       bin: bin/lua-language-server.exe
 
   version_overrides:
+    - constraint: semver:<=3.8.3
+      id: pkg:github/LuaLS/lua-language-server@3.8.3
+      asset:
+        - target: darwin_arm64
+          file: lua-language-server-{{version}}-darwin-arm64.tar.gz:libexec/
+          bin: exec:libexec/bin/lua-language-server
+        - target: darwin_x64
+          file: lua-language-server-{{version}}-darwin-x64.tar.gz:libexec/
+          bin: exec:libexec/bin/lua-language-server
+        - target: linux_x64_gnu
+          file: lua-language-server-{{version}}-linux-x64.tar.gz:libexec/
+          bin: exec:libexec/bin/lua-language-server
+        - target: linux_x64_musl
+          file: lua-language-server-{{version}}-linux-x64-musl.tar.gz:libexec/
+          bin: exec:libexec/bin/lua-language-server
+        - target: win_x64
+          file: lua-language-server-{{version}}-win32-x64.zip
+          bin: bin/lua-language-server.exe
     - constraint: semver:<=3.7.4
       id: pkg:github/LuaLS/lua-language-server@3.7.4
       asset:


### PR DESCRIPTION
## Describe your changes
Restore linux_arm64_gnu target as the related lua-language-server build is fixed in v3.9.0.

## Issue ticket number and link
The target was removed because linux-arm64 package was missing in v3.8.0 and v3.8.3 (#5434).

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

## Screenshots
