### PR TITLE
Added support for Swift LSP

### DIFF
--- a/packages/sourcekit/package.yaml
+++ b/packages/sourcekit/package.yaml
@@ -1,0 +1,28 @@
+---
+name: sourcekit-lsp
+description: |
+  This extension adds language support for Swift to neovim IDE. It supports:
+    Code completion
+    Jump to definition, peek definition, find all references, symbol search
+    Error annotations and apply suggestions from errors
+    Automatic generation of launch configurations for debugging with CodeLLDB
+    Automatic task creation
+    Package dependency view
+    Test Explorer view
+   Swift support uses SourceKit LSP for the language server to power code completion and LLDB to enable debugging. The extension is developed by members of the Swift Community and maintained by the SSWG. The aim is to provide a first-class, feature complete extension to make developing Swift applications on all platforms a seamless experience. https://github.com/swift-server/vscode-swift
+homepage: https://www.swift.org/
+licenses:
+  - Apache-2.0
+languages:
+  - Swift
+categories:
+  - LSP
+
+source:
+  id: pkg:openvsx/sswg/swift-lang@1.9.0
+  download:
+    file: sswg.swift-lang-{{ version }}.vsix
+
+bin:
+  sourcekit: node:extension/dist/extension.js
+


### PR DESCRIPTION
## Describe your changes
Added a Swift LSP support in neovim. Started working with Swift code in Linux using neovim. Found that there was no support for LSP binidings in Mason, hence took some time to introduce sourcekit-lsp for Swift programming language. There exists a VS code extension maintained by SSWC, I'm creating required mason-registry to pull it from the VSX repository.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review

- [ x] I have successfully tested installation of the package.
- [ x] I have successfully tested the package after installation.


## Screenshots

