### PR TITLE
fix(gleam): update deprecation message with more context

### DIFF
--- a/packages/gleam/package.yaml
+++ b/packages/gleam/package.yaml
@@ -12,7 +12,7 @@ categories:
   - LSP
 
 deprecation:
-  message: Gleam should not be installed through Mason.
+  message: Gleam's LSP is included in its toolchain, so avoid installing it through Mason to prevent version mismatches. For more details, visit https://gleam.run/language-server/#neovim
   since: v1.0.0
 
 source:


### PR DESCRIPTION
## Describe your changes
The Gleam's LSP is bundled with the rest of its toolchain. To avoid version conflicts, it is recommended to not have Mason manage the LSP. This resulted in an original deprecation message that was added. The message could use a bit more context as to not confuse those getting started with Gleam.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
![image](https://github.com/mason-org/mason-registry/assets/1228424/b61387a6-7115-44ed-b68f-eabadac00dc6)
