### PR TITLE
feat(astro): add `@astrojs/ts-plugin` as extra package to `astro-language-server`

### DIFF
--- a/packages/astro-language-server/package.yaml
+++ b/packages/astro-language-server/package.yaml
@@ -13,6 +13,7 @@ source:
   id: pkg:npm/%40astrojs/language-server@2.10.0
   extra_packages:
     - typescript
+    - "@astrojs/ts-plugin"
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/withastro/language-tools/@astrojs/language-server@{{version}}/packages/vscode/package.json


### PR DESCRIPTION
## Describe your changes
Support for importing astro files in a typescript file needs to be setup by adding the `@astrojs/ts-plugin` as a plugin to `tsserver` or `vtsls`.

The `@astrojs/ts-plugin` has been added as an extra package, so that it's easy to add this to `vtsls`.

See https://github.com/withastro/language-tools/tree/main/packages/ts-plugin

The plugin is part of the overall astro language tools that also includes the astro language server.

A similar thing is needed for vue projects, but luckily the ts plugin is already part of the volar package.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
