### PR TITLE
feat: add fish-lsp

### DIFF
--- a/packages/fish-lsp/package.yaml
+++ b/packages/fish-lsp/package.yaml
@@ -1,0 +1,20 @@
+---
+name: fish-lsp
+description: LSP implementation for the fish shell langauge
+homepage: https://www.fish-lsp.dev/
+licenses:
+  - MIT
+languages:
+  - Fish
+categories:
+  - LSP
+
+source:
+  # renovate:datasource=github-tags
+  id: pkg:github/ndonfris/fish-lsp@af5d298855406a134aa7cc26740a8d387ab3c2e1
+  build:
+    run: |
+      yarn install
+
+bin:
+  fish-lsp: bin/fish-lsp

--- a/schemas/enums/language.json
+++ b/schemas/enums/language.json
@@ -62,6 +62,7 @@
         "F#",
         "Facility Service Definition",
         "Fennel",
+        "Fish",
         "Flow",
         "Flux",
         "Fortran",


### PR DESCRIPTION
## Describe your changes
adding fish-lsp as it is recently supported by nvim-lspconfig.
Though fish and node version 21.7.1 are dependencies (!)

## Issue ticket number and link

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
