### PR TITLE
bump(cobol-language-support): downgrade to v2.1.1

### DIFF
--- a/packages/cobol-language-support/package.yaml
+++ b/packages/cobol-language-support/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/eclipse-che4z/che-che4z-lsp-for-cobol@2.1.2
+  id: pkg:github/eclipse-che4z/che-che4z-lsp-for-cobol@2.1.1
   asset:
     - target: darwin_arm64
       file: cobol-language-support-darwin-arm64-{{version}}.vsix


### PR DESCRIPTION
Reverts mason-org/mason-registry#5675