### PR TITLE
added support for typespec lsp

### DIFF
--- a/packages/tsp-server/package.yaml
+++ b/packages/tsp-server/package.yaml
@@ -1,0 +1,16 @@
+---
+name: tsp-server
+description: ⚡ LSP for ther typespec language.
+homepage: https://github.com/microsoft/typespec
+licenses:
+  - MIT
+languages:
+  - Typespec
+categories:
+  - LSP
+
+source:
+  id: pkg:npm/%40typespec/compiler@0.56.0
+
+bin:
+  tsp-server: npm:tsp-server


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Hey, 
i added the typespec lsp pkg. 
the lsp is bundled with the typespec compiler so it will install both.
The LSP bin is tsp-server.
## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
