### PR TITLE
fix: downgrade autotools-language-server from 0.0.19 to 0.0.18

### DIFF
--- a/packages/autotools-language-server/package.yaml
+++ b/packages/autotools-language-server/package.yaml
@@ -9,7 +9,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:pypi/autotools-language-server@0.0.19
+  id: pkg:pypi/autotools-language-server@0.0.18
 
 bin:
   autotools-language-server: pypi:autotools-language-server

--- a/renovate.json5
+++ b/renovate.json5
@@ -106,6 +106,10 @@
         {
             matchDepNames: ["ansible-language-server"],
             allowedVersions: "!/1\\.2\\.2/"
+        },
+        {
+            matchDepNames: ["autotools-language-server"],
+            allowedVersions: "!/0\\.0\\.19/"
         }
     ],
     "ignoreDeps": [


### PR DESCRIPTION
## Describe your changes
Downgrade `autotools-language-server` from `0.0.19` to `0.0.18`.

See issue for explanation as to why.

## Issue ticket number and link
https://github.com/mason-org/mason-registry/issues/6049

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

## Screenshots