### PR TITLE
bump(haskell-language-server): Update to version 2.8.0.0

### DIFF
--- a/packages/haskell-language-server/package.yaml
+++ b/packages/haskell-language-server/package.yaml
@@ -11,7 +11,7 @@ categories:
 
 source:
   # renovate:datasource=github-releases
-  id: pkg:generic/haskell/haskell-language-server@2.7.0.0
+  id: pkg:generic/haskell/haskell-language-server@2.8.0.0
   build:
     - target: unix
       run: ghcup install hls "$VERSION" -i "$PWD"
@@ -22,7 +22,7 @@ source:
         wrapper: bin/haskell-language-server-wrapper
         server_9_2_8: bin/haskell-language-server-9.2.8
         server_9_4_8: bin/haskell-language-server-9.4.8
-        server_9_6_4: bin/haskell-language-server-9.6.4
+        server_9_6_5: bin/haskell-language-server-9.6.5
         server_9_8_2: bin/haskell-language-server-9.8.2
 
     - target: win
@@ -34,7 +34,7 @@ source:
         wrapper: haskell-language-server-wrapper.exe
         server_9_2_8: haskell-language-server-9.2.8.exe
         server_9_4_8: haskell-language-server-9.4.8.exe
-        server_9_6_4: haskell-language-server-9.6.4.exe
+        server_9_6_5: haskell-language-server-9.6.5.exe
         server_9_8_2: haskell-language-server-9.8.2.exe
 
 bin:
@@ -42,5 +42,5 @@ bin:
   # https://github.com/haskell/haskell-language-server/issues/3162
   haskell-language-server-9.2.8: "{{source.build.bin.server_9_2_8}}"
   haskell-language-server-9.4.8: "{{source.build.bin.server_9_4_8}}"
-  haskell-language-server-9.6.4: "{{source.build.bin.server_9_6_4}}"
+  haskell-language-server-9.6.5: "{{source.build.bin.server_9_6_5}}"
   haskell-language-server-9.8.2: "{{source.build.bin.server_9_8_2}}"


### PR DESCRIPTION
## Describe your changes
Bumps package version for the Haskell Language Server

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->
