### PR TITLE
feat: add language-server-bitbake

### DIFF
--- a/packages/language-server-bitbake/package.yaml
+++ b/packages/language-server-bitbake/package.yaml
@@ -1,0 +1,19 @@
+---
+name: language-server-bitbake
+description: A language server for BitBake.
+homepage: https://github.com/yoctoproject/vscode-bitbake
+licenses:
+  - MIT
+languages:
+  - Bitbake
+categories:
+  - LSP
+
+source:
+  id: pkg:npm/language-server-bitbake@2.5.0
+
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/yoctoproject/vscode-bitbake/v{{version}}/server/package.json
+
+bin:
+  language-server-bitbake: npm:language-server-bitbake

--- a/packages/language-server-bitbake/package.yaml
+++ b/packages/language-server-bitbake/package.yaml
@@ -12,8 +12,5 @@ categories:
 source:
   id: pkg:npm/language-server-bitbake@2.5.0
 
-schemas:
-  lsp: vscode:https://raw.githubusercontent.com/yoctoproject/vscode-bitbake/v{{version}}/server/package.json
-
 bin:
   language-server-bitbake: npm:language-server-bitbake


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->

This commit adds a language server for BitBake, which is documented [here](https://github.com/yoctoproject/vscode-bitbake/tree/staging/server) and is also available as an npm package [here](https://www.npmjs.com/package/language-server-bitbake). The language server is already implemented in nvim-lspconfig as [bitbake_ls](https://github.com/neovim/nvim-lspconfig/blob/master/doc/server_configurations.md#bitbake_ls).

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

Tested installation via `:Mason`  after pointing at a local registry with:

```lua
require("mason").setup({
    registries = {
        "file:~/git/mason-registry",
    },
})
```

Tested the language server itself with:

```lua
require("lspconfig").bitbake_ls.setup()
```

## Screenshots
<!-- Leave empty if not applicable -->
