### PR TITLE
added VSG (a verilog formatter by jeremiah-c-leary/vhdl-style-guide)

### DIFF
--- a/packages/vsg/package.yaml
+++ b/packages/vsg/package.yaml
@@ -1,0 +1,16 @@
+---
+name: vsg
+description: VHDL Style Guide (VSG), Coding style enforcement for VHDL.
+homepage: https://pypi.org/project/vsg/
+licenses:
+  - GPL-3.0
+languages:
+  - VHDL
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/vsg@3.24.0
+
+bin:
+  vsg: pypi:vsg

--- a/packages/vsg/package.yaml
+++ b/packages/vsg/package.yaml
@@ -8,6 +8,7 @@ languages:
   - VHDL
 categories:
   - Formatter
+  - Linter
 
 source:
   id: pkg:pypi/vsg@3.24.0


### PR DESCRIPTION
## Describe your changes
I added [VSG](https://github.com/jeremiah-c-leary/vhdl-style-guide) which is a VHDL formatter.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->
      
Simply installing VSG from mason and using the following lua for [conform.nvim](https://github.com/stevearc/conform.nvim/blob/797d1f622a23d4a21bb58218bdf5999a9beac4ef/lua/conform/formatters/vsg.lua#L8) (which already supports VSG) provides full support:

```lua
        require("conform").setup({
            formatters_by_ft = {
                vhdl = { "vsg" },
            },
        })
```

## Screenshots
<!-- Leave empty if not applicable -->
