### PR TITLE
feat: Add brunette package.yaml file for Python code formatter

### DIFF
--- a/packages/brunette/package.yaml
+++ b/packages/brunette/package.yaml
@@ -1,0 +1,16 @@
+---
+name: brunette
+description: A best practice Python code formatter
+homepage: https://github.com/odwyersoftware/brunette
+licenses:
+  - MIT
+languages:
+  - Python
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/brunette@0.2.8
+
+bin:
+  brunette: pypi:brunette


### PR DESCRIPTION
## Describe your changes
Added `brunette` as an alternative to `black` formatted for Python

## Issue ticket number and link

## Checklist before requesting a review
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.

I have not been able to test the registry as I use nvim nightly and it did not work with either of the options:
```
require("mason").setup({
    registries = {
        "repo:mason-org/mason-registry",
        -- "repo:Zananok/mason-registry",
    },
})
```

Same format as `black`. I.e. just install using mason from the list and configure with something like conform:
```
                    local conform = require("conform")
                    conform.setup({
                        formatters_by_ft = {
                            python = { "brunette" },
                        },
                    })
```

## Screenshots
<!-- Leave empty if not applicable -->
