### PR TITLE
Fix: Correct rust_hdl library installation

### DIFF
--- a/packages/rust_hdl/package.yaml
+++ b/packages/rust_hdl/package.yaml
@@ -17,17 +17,17 @@ source:
     - target: darwin_arm64
       file: vhdl_ls-aarch64-apple-darwin.zip
       bin: vhdl_ls-aarch64-apple-darwin/bin/vhdl_ls
-      libraries: vhdl_ls-aarch64-apple-darwin/vhdl_libraries
+      libraries: vhdl_ls-aarch64-apple-darwin/vhdl_libraries/
     - target: linux_x64
       file: vhdl_ls-x86_64-unknown-linux-musl.zip
       bin: vhdl_ls-x86_64-unknown-linux-musl/bin/vhdl_ls
-      libraries: vhdl_ls-x86_64-unknown-linux-musl/vhdl_libraries
+      libraries: vhdl_ls-x86_64-unknown-linux-musl/vhdl_libraries/
     - target: win_x64
       file: vhdl_ls-x86_64-pc-windows-msvc.zip
       bin: vhdl_ls-x86_64-pc-windows-msvc/bin/vhdl_ls.exe
-      libraries: vhdl_ls-x86_64-pc-windows-msvc/bin/vhdl_libraries
+      libraries: vhdl_ls-x86_64-pc-windows-msvc/bin/vhdl_libraries/
 
 bin:
   vhdl_ls: "{{source.asset.bin}}"
 share:
-  vhdl_libraries/: "./{{source.asset.libraries}}/"
+  vhdl_libraries/: "{{source.asset.libraries}}"

--- a/packages/rust_hdl/package.yaml
+++ b/packages/rust_hdl/package.yaml
@@ -17,12 +17,17 @@ source:
     - target: darwin_arm64
       file: vhdl_ls-aarch64-apple-darwin.zip
       bin: vhdl_ls-aarch64-apple-darwin/bin/vhdl_ls
+      libraries: vhdl_ls-aarch64-apple-darwin/vhdl_libraries
     - target: linux_x64
       file: vhdl_ls-x86_64-unknown-linux-musl.zip
       bin: vhdl_ls-x86_64-unknown-linux-musl/bin/vhdl_ls
+      libraries: vhdl_ls-x86_64-unknown-linux-musl/vhdl_libraries
     - target: win_x64
       file: vhdl_ls-x86_64-pc-windows-msvc.zip
       bin: vhdl_ls-x86_64-pc-windows-msvc/bin/vhdl_ls.exe
+      libraries: vhdl_ls-x86_64-pc-windows-msvc/bin/vhdl_libraries
 
 bin:
   vhdl_ls: "{{source.asset.bin}}"
+share:
+  vhdl_libraries/: "./{{source.asset.libraries}}/"


### PR DESCRIPTION
## Describe your changes
rust_hdl installation instructions did not include the libraries required

## Issue ticket number and link
https://github.com/mason-org/mason-registry/issues/6139

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
<img width="703" alt="image" src="https://github.com/mason-org/mason-registry/assets/34587047/2c91ae17-27fa-4af3-a5f3-40d0140546c7">.     
    
   


<img width="651" alt="image" src="https://github.com/mason-org/mason-registry/assets/34587047/59ca86de-b99a-45dc-bf00-5240a9b177c7">

