### PR TITLE
fix(zls): use lsp config schema from ZLS instead of vscode-zig

### DIFF
--- a/packages/zls/package.yaml
+++ b/packages/zls/package.yaml
@@ -84,7 +84,7 @@ source:
 
 
 schemas:
-  lsp: vscode:https://raw.githubusercontent.com/ziglang/vscode-zig/master/package.json
+  lsp: https://raw.githubusercontent.com/zigtools/zls/{{version}}/schema.json
 
 bin:
   zls: "{{source.asset.bin}}"


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->

The LSP config options for [ZLS](https://github.com/zigtools/zls) are currently provided by using the [package.json](https://github.com/ziglang/vscode-zig/blob/master/package.json) from the [vscode-zig](https://github.com/ziglang/vscode-zig) extension. This has some unfortunate issues:
- some config options are not related to ZLS
- the names don't match since vscode-zig converts them to camelCase
- the default values may be different (e.g `semantic_tokens` is `"partial"` in vscode-zig)

ZLS does provide a [json schema](https://github.com/zigtools/zls/blob/master/schema.json) for all of its configuration options so there is no need to depend on anything else. And it obviously matches exactly what ZLS provides.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->

### Before
![Screenshot from 2024-06-22 13-15-57](https://github.com/mason-org/mason-registry/assets/19954306/1f2ba4c7-388b-417e-b786-fcd78f976d60)

### After
![Screenshot from 2024-06-22 13-16-39](https://github.com/mason-org/mason-registry/assets/19954306/aa5d3e87-15aa-4130-80aa-5a2d06cdb2cb)
