### PR TITLE
feat: add protols LSP for protobuf

### DIFF
--- a/packages/protols/package.yaml
+++ b/packages/protols/package.yaml
@@ -1,0 +1,16 @@
+---
+name: protols
+description: A Simple LSP for proto3 protobuf files.
+homepage: https://github.com/coder3101/protols
+licenses:
+  - MIT
+languages:
+  - Protobuf
+categories:
+  - LSP
+
+source:
+  id: pkg:cargo/protols@0.1.1
+
+bin:
+  protols: cargo:protols


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Add an LSP for protocol buffer with support for:

- Hover
- Diagnostics
- Go to Definition
- Rename
- Completion

Originally: https://github.com/coder3101/protols

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
