### PR TITLE
feat: angularls add lts on version_overrides

### DIFF
--- a/packages/angular-language-server/package.yaml
+++ b/packages/angular-language-server/package.yaml
@@ -17,45 +17,49 @@ source:
     - typescript@5.1.3
 
   version_overrides:
-    - constraint: semver:<=14.1.0
-      id: pkg:npm/%40angular/language-server@14.1.0
+    - constraint: semver:<=17.3.11
+      id: pkg:npm/%40angular/language-server@17.3.11
       extra_packages:
-        - typescript@4.7.4
+        - typescript@5.4.2
 
-    - constraint: semver:<=14.0.1
-      id: pkg:npm/%40angular/language-server@14.0.1
+    - constraint: semver:<=16.2.12
+      id: pkg:npm/%40angular/language-server@16.2.12
       extra_packages:
-        - typescript@4.5.4
+        - typescript@5.1.3
 
-    - constraint: semver:<=13.3.4
-      id: pkg:npm/%40angular/language-server@13.3.4
+    - constraint: semver:<=15.2.10
+      id: pkg:npm/%40angular/language-server@15.2.10
       extra_packages:
-        - typescript@~4.6.2
+        - typescript@4.9.3
 
-    - constraint: semver:<=13.2.6
-      id: pkg:npm/%40angular/language-server@13.2.6
+    - constraint: semver:<=14.3.0
+      id: pkg:npm/%40angular/language-server@14.3.0
       extra_packages:
-        - typescript@4.5.4
+        - typescript@4.8.2
 
-    - constraint: semver:<=13.1.1
-      id: pkg:npm/%40angular/language-server@13.1.1
+    - constraint: semver:<=13.4.0
+      id: pkg:npm/%40angular/language-server@13.4.0
       extra_packages:
-        - typescript@4.4.3
+        - typescript@4.6.2
 
-    - constraint: semver:<=12.2.3
-      id: pkg:npm/%40angular/language-server@12.2.3
+    - constraint: semver:<=12.2.17
+      id: pkg:npm/%40angular/language-server@12.2.17
       extra_packages:
         - typescript@4.3.4
-
-    - constraint: semver:<=12.0.5
-      id: pkg:npm/%40angular/language-server@12.0.5
-      extra_packages:
-        - typescript@4.2.4
 
     - constraint: semver:<=11.2.14
       id: pkg:npm/%40angular/language-server@11.2.14
       extra_packages:
-        - typescript@4.1.5
+        - typescript@4.1.2
 
+    - constraint: semver:<=10.2.5
+      id: pkg:npm/%40angular/language-server@10.2.5
+      extra_packages:
+        - typescript@4.0.2
+
+    - constraint: semver:<=9.1.13
+      id: pkg:npm/%40angular/language-server@9.1.13
+      extra_packages:
+        - typescript@3.8.3
 bin:
   ngserver: npm:ngserver


### PR DESCRIPTION
## Describe your changes
I having trouble on angulals v18, it will exit with error looking for a file named `ngtypecheck.ts` and I want to other lts version of angularls and it is not available on the registery, the latest version after v18 is v14. With this pull request I added lts version from v9 to v17 

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
