### PR TITLE
feat: angularls 1 major version per version on version_overrides

### DIFF
--- a/packages/angular-language-server/package.yaml
+++ b/packages/angular-language-server/package.yaml
@@ -17,40 +17,35 @@ source:
     - typescript@5.1.3
 
   version_overrides:
-    - constraint: semver:<=14.1.0
-      id: pkg:npm/%40angular/language-server@14.1.0
+    - constraint: semver:<=17.3.2
+      id: pkg:npm/%40angular/language-server@17.3.2
       extra_packages:
-        - typescript@4.7.4
+        - typescript@5.3.2
 
-    - constraint: semver:<=14.0.1
-      id: pkg:npm/%40angular/language-server@14.0.1
+    - constraint: semver:<=16.2.0
+      id: pkg:npm/%40angular/language-server@16.2.0
       extra_packages:
-        - typescript@4.5.4
+        - typescript@5.1.3
+
+    - constraint: semver:<=15.2.1
+      id: pkg:npm/%40angular/language-server@15.2.1
+      extra_packages:
+        - typescript@4.8.2
+
+    - constraint: semver:<=14.2.0
+      id: pkg:npm/%40angular/language-server@14.2.0
+      extra_packages:
+        - typescript@4.8.2
 
     - constraint: semver:<=13.3.4
       id: pkg:npm/%40angular/language-server@13.3.4
       extra_packages:
-        - typescript@~4.6.2
-
-    - constraint: semver:<=13.2.6
-      id: pkg:npm/%40angular/language-server@13.2.6
-      extra_packages:
-        - typescript@4.5.4
-
-    - constraint: semver:<=13.1.1
-      id: pkg:npm/%40angular/language-server@13.1.1
-      extra_packages:
-        - typescript@4.4.3
+        - typescript@4.6.2
 
     - constraint: semver:<=12.2.3
       id: pkg:npm/%40angular/language-server@12.2.3
       extra_packages:
         - typescript@4.3.4
-
-    - constraint: semver:<=12.0.5
-      id: pkg:npm/%40angular/language-server@12.0.5
-      extra_packages:
-        - typescript@4.2.4
 
     - constraint: semver:<=11.2.14
       id: pkg:npm/%40angular/language-server@11.2.14

--- a/packages/angular-language-server/package.yaml
+++ b/packages/angular-language-server/package.yaml
@@ -14,7 +14,7 @@ categories:
 source:
   id: pkg:npm/%40angular/language-server@18.0.0
   extra_packages:
-    - typescript@5.1.3
+    - typescript@5.4.5
 
   version_overrides:
     - constraint: semver:<=17.3.2


### PR DESCRIPTION
## Describe your changes
I having trouble on angulals v18, it will exit with error looking for a file named ngtypecheck.ts and I want to other lts version of angularls and it is not available on the registery, the latest version after v18 is v14. With this pull request I added lts version from v9 to v17

## Issue ticket number and link
Just for a reference there is an open issue open 4 days ago (Jun 24, 2024)
https://github.com/angular/vscode-ng-language-service/issues/2043

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
