### PR TITLE
feat(phpactor): update to v2024.06.30.0 and switch to phar installation

### DIFF
--- a/packages/phpactor/package.yaml
+++ b/packages/phpactor/package.yaml
@@ -15,9 +15,8 @@ source:
   # renovate:versioning=loose
   # renovate:datasource=github-tags
   id: pkg:github/phpactor/phpactor@2024.06.30.0
-  build:
-    - target: unix
-      run: composer install --no-interaction --no-dev --optimize-autoloader --classmap-authoritative
+  asset:
+    file: phpactor.phar
 
 bin:
-  phpactor: bin/phpactor
+  phpactor: php:phpactor.phar

--- a/packages/phpactor/package.yaml
+++ b/packages/phpactor/package.yaml
@@ -14,7 +14,7 @@ categories:
 source:
   # renovate:versioning=loose
   # renovate:datasource=github-tags
-  id: pkg:github/phpactor/phpactor@2024.03.09.0
+  id: pkg:github/phpactor/phpactor@2024.06.30.0
   build:
     - target: unix
       run: composer install --no-interaction --no-dev --optimize-autoloader --classmap-authoritative


### PR DESCRIPTION
## Describe your changes
In its latest version, phpactor seems to have achieved windows support. We can switch to install their provided PHAR to reduce installation overhead.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
