### PR TITLE
bump(oxlint): update to 0.5.2

### DIFF
--- a/packages/oxlint/package.yaml
+++ b/packages/oxlint/package.yaml
@@ -18,9 +18,9 @@ source:
     - target: darwin_x64
       file: oxlint-darwin-x64
     - target: linux_arm64_gnu
-      file: oxlint-linux-arm64
+      file: oxlint-linux-arm64-gnu
     - target: linux_x64_gnu
-      file: oxlint-linux-x64
+      file: oxlint-linux-x64-gnu
     - target: win_arm64
       file: oxlint-win32-arm64.exe
     - target: win_x64

--- a/packages/oxlint/package.yaml
+++ b/packages/oxlint/package.yaml
@@ -11,7 +11,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:github/web-infra-dev/oxc@oxlint_v0.0.20
+  id: pkg:github/web-infra-dev/oxc@oxlint_v0.5.2
   asset:
     - target: darwin_arm64
       file: oxlint-darwin-arm64

--- a/packages/oxlint/package.yaml
+++ b/packages/oxlint/package.yaml
@@ -11,7 +11,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:github/web-infra-dev/oxc@oxlint_v0.5.2
+  id: pkg:github/web-infra-dev/oxc@oxlint_v0.5.3
   asset:
     - target: darwin_arm64
       file: oxlint-darwin-arm64


### PR DESCRIPTION
## Describe your changes
- update to latest oxlint version 0.5.2
- fixes issue https://github.com/mfussenegger/nvim-lint/issues/595 in `nvim-lint`
  - the current version of `oxlint` Mason installs doesn't understand the `--format` arg used in the lint config, causing no diagnostics to show inside of nvim
- I have tested the new version as outlined below and can confirm it works, fixing the issue above

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->
