### PR TITLE
Bump java-test

### DIFF
--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -21,7 +21,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:openvsx/vscjava/vscode-java-test@0.40.1
+  id: pkg:openvsx/vscjava/vscode-java-test@0.41.1
   download:
     file: vscjava.vscode-java-test-{{version}}.vsix
 


### PR DESCRIPTION
## Describe your changes
jdtls 1.37.0 doesn't work with the current version of java-test.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
