### PR TITLE
bump(elp): update to v2024-07-16

### DIFF
--- a/packages/elp/package.yaml
+++ b/packages/elp/package.yaml
@@ -13,16 +13,16 @@ categories:
 
 source:
   # renovate:versioning=loose
-  id: pkg:github/WhatsApp/erlang-language-platform@2024-06-07
+  id: pkg:github/WhatsApp/erlang-language-platform@2024-07-16
   asset:
     - target: linux_x64_gnu
-      file: elp-linux-x86_64-unknown-linux-gnu-otp-25.3.tar.gz
+      file: elp-linux-x86_64-unknown-linux-gnu-otp-26.2.tar.gz
       bin: elp
     - target: darwin_x64
-      file: elp-macos-x86_64-apple-darwin-otp-25.3.tar.gz
+      file: elp-macos-x86_64-apple-darwin-otp-26.2.tar.gz
       bin: elp
     - target: darwin_arm64
-      file: elp-macos-aarch64-apple-darwin-otp-25.3.tar.gz
+      file: elp-macos-aarch64-apple-darwin-otp-26.2.tar.gz
       bin: elp
 
 schemas:


### PR DESCRIPTION
## Describe your changes

Supersedes https://github.com/mason-org/mason-registry/pull/6493

Bump `elp`. The new version is built using a newer Erlang/OTP version and therefore the file names changed as well.

## Issue ticket number and link
https://github.com/mason-org/mason-registry/pull/6493 has test failures. This PR should resolve this.

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->