### PR TITLE
feat: add superhtml package

### DIFF
--- a/packages/superhtml/package.yaml
+++ b/packages/superhtml/package.yaml
@@ -1,0 +1,36 @@
+name: superhtml
+description: HTML Language Server & Templating Language Library
+homepage: https://github.com/kristoff-it/superhtml
+licenses:
+  - MIT
+languages:
+  - HTML
+  - SuperHTML
+categories:
+  - LSP
+  - Formatter
+
+source:
+  id: pkg:github/kristoff-it/superhtml@v0.5.3
+  asset:
+    - target: darwin_arm64
+      file: aarch64-macos.tar.gz
+      bin: aarch64-macos/superhtml
+    - target: linux_arm64
+      file: aarch64-linux.tar.gz
+      bin: aarch64-linux/superhtml
+    - target: win_arm64
+      file: aarch64-windows.zip
+      bin: aarch64-windows/superhtml.exe
+    - target: darwin_x64
+      file: x86_64-macos.tar.gz
+      bin: x86_64-macos/superhtml
+    - target: linux_x64_musl
+      file: x86_64-linux-musl.tar.gz
+      bin: x86_64-linux-musl/superhtml
+    - target: win_x64
+      file: x86_64-windows.zip
+      bin: x86_64-windows/superhtml.exe
+
+bin:
+  superhtml: "{{source.asset.bin}}"


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Added the superhtml lsp to the list of packages that mason can install.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
Example using mason-lspconfig (PR coming soon)
<img width="492" alt="image" src="https://github.com/user-attachments/assets/c93cd0e4-67db-48db-ba82-9468cc6e755c">

LSP Showint up in :LspInfo
<img width="641" alt="image" src="https://github.com/user-attachments/assets/a87cbb6a-a738-4e25-b743-70b0114c7d8d">

Installed through Mason
<img width="573" alt="image" src="https://github.com/user-attachments/assets/c2cc4d18-2562-471b-82d2-d1659ca96f0b">
<img width="441" alt="image" src="https://github.com/user-attachments/assets/dc1a5b06-b4da-47d4-98c3-1b78d90ba7c7">

Not quite ready for prime time since the LSP itself doesn't fully work yet (that or I've set it up wrong) https://github.com/kristoff-it/superhtml/issues/20.