### PR TITLE
chore: add deprecated message for theme-check

### DIFF
--- a/packages/shopify-theme-check/package.yaml
+++ b/packages/shopify-theme-check/package.yaml
@@ -1,5 +1,8 @@
 ---
 name: shopify-theme-check
+deprecation:
+  since: v1.15.0
+  message: Theme-check has deprecated, use shopify-cli(shopify_theme_ls) instead, its successor.
 description: The Ultimate Shopify Theme Linter.
 homepage: https://github.com/Shopify/theme-check
 licenses:


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->

Add deprecated message for theme-check since the repo is archived, moved to [Shopify/theme-tools](https://github.com/Shopify/theme-tools).

see https://github.com/Shopify/theme-check

It took me sometime to figure out `shopify-cli` has wrapped the new theme check lsp. Hope this can help some people.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
