### PR TITLE
feat: add nixd

### DIFF
--- a/packages/nixd/package.yaml
+++ b/packages/nixd/package.yaml
@@ -1,0 +1,28 @@
+---
+name: nixd
+description: Language Server for Nix.
+homepage: https://github.com/nix-community/nixd
+licenses:
+  - LGPL-3.0
+languages:
+  - Nix
+categories:
+  - LSP
+
+source:
+  # renovate:datasource=github-tags
+  id: pkg:github/nix-community/nixd@2.3.2
+  supported_platforms:
+    - darwin_arm64
+    - darwin_x64
+    - linux_arm64
+    - linux_arm64_gnu
+    - linux_arm_gnu
+    - linux_x64
+    - linux_x64_gnu
+  build:
+    run: nix build '.#nixd'
+    bin: result/bin/nixd
+
+bin:
+  nixd: "{{source.build.bin}}"


### PR DESCRIPTION
## Describe your changes

Adds a package for [nixd](https://github.com/nix-community/nixd), a Nix language server.

Supersedes / closes #4822, which was seemlingly abandonned by its author.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots

<img width="959" alt="Screenshot 2024-08-02 at 14 21 04" src="https://github.com/user-attachments/assets/ad48e05d-372e-4d97-abdf-1a4c44ad41d2">