### PR TITLE
feat: add daedalus-language-server

### DIFF
--- a/packages/daedalus-language-server/package.yaml
+++ b/packages/daedalus-language-server/package.yaml
@@ -1,0 +1,34 @@
+---
+name: daedalus-language-server
+description: A LanguageServer implementation in Go for the scripting language Daedalus used in Gothic and Gothic II games
+homepage: https://github.com/kirides/DaedalusLanguageServer
+licenses:
+  - MIT
+languages:
+  - Daedalus
+categories:
+  - LSP
+
+source:
+  id: pkg:github/kirides/DaedalusLanguageServer@v1.0.0
+  asset:
+    - target: linux_x64_gnu
+      file: linux_amd64.zip
+      bin: DaedalusLanguageServer
+    - target: linux_arm64_gnu
+      file: linux_arm64.zip
+      bin: DaedalusLanguageServer
+    - target: darwin_x64
+      file: darwin_amd64.zip
+      bin: DaedalusLanguageServer
+    - target: darwin_arm64
+      file: darwin_arm64.zip
+      bin: DaedalusLanguageServer
+    - target: win_x64
+      file: windows_amd64.zip
+      bin: DaedalusLanguageServer.exe
+    - target: win_arm64
+      file: windows_arm64.zip
+      bin: DaedalusLanguageServer.exe
+bin:
+  daedalus: "{{source.asset.bin}}"


### PR DESCRIPTION
## Describe your changes
This PR adds a package for (https://github.com/kirides/DaedalusLanguageServer) used by Gothic and Gothic II games.
## Issue ticket number and link

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
