### PR TITLE
bump(nil): update to 2024-08-06

### DIFF
--- a/packages/nil/package.yaml
+++ b/packages/nil/package.yaml
@@ -12,7 +12,7 @@ categories:
 
 source:
   # renovate:versioning=loose
-  id: pkg:cargo/nil@2023-08-09?repository_url=https://github.com/oxalica/nil
+  id: pkg:cargo/nil@2024-08-06?repository_url=https://github.com/oxalica/nil
 
 bin:
   nil: cargo:nil


### PR DESCRIPTION
## Describe your changes
Update `nil` to new [tag](https://github.com/oxalica/nil/releases/tag/2024-08-06), old one does not compile for new `nix` versions

## Issue ticket number and link
https://github.com/mason-org/mason-registry/issues/6924

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
Installed and tried on `flake.nix` file

## Screenshots
<img width="821" alt="mason-install-nil" src="https://github.com/user-attachments/assets/7ccace7e-30f1-465c-b1c7-992a0abfd1eb">
<img width="222" alt="flake.nix" src="https://github.com/user-attachments/assets/d120c6f6-8aac-45c7-a79c-687a4c64167b">
