### PR TITLE
Add scheme-langserver

### DIFF
--- a/packages/scheme-langserver/package.yaml
+++ b/packages/scheme-langserver/package.yaml
@@ -1,4 +1,4 @@
-name: Scheme-langserver
+name: scheme-langserver
 description: Provide scheme language features for example local identifier auto-complete and more.
 homepage: https://github.com/thqby/vscode-autohotkey2-lsp
 licenses:
@@ -11,7 +11,8 @@ categories:
 source:
   id: pkg:github/ufo5260987423/scheme-langserver@1.2.3
   asset:
-    target: linux_x64_gnu
+  - target: linux_x64_gnu
+    file: run
     bin: run
 bin:
   scheme-langserver: "{{source.asset.bin}}"

--- a/packages/scheme-langserver/package.yaml
+++ b/packages/scheme-langserver/package.yaml
@@ -1,0 +1,17 @@
+name: Scheme-langserver
+description: Provide scheme language features for example local identifier auto-complete and more.
+homepage: https://github.com/thqby/vscode-autohotkey2-lsp
+licenses:
+  - MIT
+languages:
+  - Scheme
+categories:
+  - LSP
+
+source:
+  id: pkg:github/ufo5260987423/scheme-langserver@1.2.3
+  asset:
+    target: linux_x64_gnu
+    bin: run
+bin:
+  scheme-langserver: "{{source.asset.bin}}"


### PR DESCRIPTION
## Describe your changes
Add scheme-langserver, a language server for scheme. 
And sorry for after so long time, I finally complete scheme-langserver a available version.

I'm not sure what should I do in mason and mason.lspconfig. I hope to hear from maintainer soon.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ x] I have successfully tested installation of the package.
- [ x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
![2024-08-21 20-25-33屏幕截图](https://github.com/user-attachments/assets/914967f6-4497-4c35-bd9b-a2be72f3596f)

![2024-08-21 21-13-15屏幕截图](https://github.com/user-attachments/assets/565cad66-0d77-4c53-bc8b-aba64f18f7ab)
