### PR TITLE
feat: add xcode-build-server

### DIFF
--- a/packages/xcode-build-server/package.yaml
+++ b/packages/xcode-build-server/package.yaml
@@ -1,0 +1,18 @@
+---
+name: xcode-build-server
+description: A server to bridge Xcode build system outside of Xcode
+homepage: https://github.com/SolaWing/xcode-build-server
+licenses:
+  - MIT
+languages:
+  - Swift
+categories:
+  - LSP
+
+source:
+  id: pkg:github/SolaWing/xcode-build-server@v1.1.0
+  build:
+    run: "echo already built"
+
+bin:
+  xcode-build-server: "xcode-build-server"

--- a/packages/xcode-build-server/package.yaml
+++ b/packages/xcode-build-server/package.yaml
@@ -15,4 +15,4 @@ source:
     run: "echo already built"
 
 bin:
-  xcode-build-server: "xcode-build-server"
+  xcode-build-server: xcode-build-server


### PR DESCRIPTION
## Describe your changes
Adds xcode-build-server to add to mason Swift packages. For use in packages like xcodebuild.nvim.

This tool allows users to build (and more) xcode projects outside of xcode, like in neovim.

## Checklist before requesting a review
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.

After installing, I can build using the tool and the xcodebuild.nvim package.


![Screenshot 2024-08-24 at 18 17 48](https://github.com/user-attachments/assets/e3576c4c-c286-4844-84fb-2abc4008aaa4)

