### PR TITLE
feat: add xcbeautify

### DIFF
--- a/packages/xcbeautify/package.yaml
+++ b/packages/xcbeautify/package.yaml
@@ -1,0 +1,23 @@
+---
+name: xcbeautify
+description: A pretty printer for xcodebuild
+homepage: https://github.com/cpisciotta/xcbeautify
+licenses:
+  - MIT
+languages:
+  - Swift
+categories:
+  - LSP
+
+source:
+  id: pkg:github/cpisciotta/xcbeautify@2.11.0
+  asset:
+    - target: linux_x64_gnu
+      file: xcbeautify-2.11.0-x86_64-unknown-linux-gnu.tar.xz
+      bin: release/xcbeautify
+    - target: darwin
+      file: xcbeautify-2.11.0-universal-apple-macosx.zip
+      bin: release/xcbeautify
+
+bin:
+  xcbeautify: "{{source.asset.bin}}"


### PR DESCRIPTION
## Describe your changes
Adds xcbeautify, used to prettify xcodebuild outputs. For use in packages like xcodebuild.nvim

## Checklist before requesting a review
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.

