### PR TITLE
Upgrade the gitui to 0.26.3

### DIFF
--- a/packages/gitui/package.yaml
+++ b/packages/gitui/package.yaml
@@ -8,10 +8,13 @@ languages: []
 categories: []
 
 source:
-  id: pkg:github/extrawurst/gitui@v0.26.2
+  id: pkg:github/extrawurst/gitui@v0.26.3
   asset:
-    - target: [darwin_x64, darwin_arm64]
+    - target: [darwin_arm64]
       file: gitui-mac.tar.gz
+      bin: gitui
+    - target: [darwin_x64]
+      file: gitui-mac-x86.tar.gz
       bin: gitui
     - target: linux_x64
       file: gitui-linux-x86_64.tar.gz
@@ -27,8 +30,8 @@ source:
       bin: gitui.exe
 
   version_overrides:
-    - constraint: semver:<=v0.25.2
-      id: pkg:github/extrawurst/gitui@v0.25.2
+    - constraint: semver:<=v0.26.2
+      id: pkg:github/extrawurst/gitui@v0.26.2
       asset:
         - target: [darwin_x64, darwin_arm64]
           file: gitui-mac.tar.gz

--- a/packages/gitui/package.yaml
+++ b/packages/gitui/package.yaml
@@ -37,6 +37,25 @@ source:
           file: gitui-mac.tar.gz
           bin: gitui
         - target: linux_x64
+          file: gitui-linux-x86_64.tar.gz
+          bin: gitui
+        - target: linux_arm64
+          file: gitui-linux-aarch64.tar.gz
+          bin: gitui
+        - target: linux_arm
+          file: gitui-linux-arm.tar.gz
+          bin: gitui
+        - target: win_x64
+          file: gitui-win.tar.gz
+          bin: gitui.exe
+
+    - constraint: semver:<=v0.25.2
+      id: pkg:github/extrawurst/gitui@v0.25.2
+      asset:
+        - target: [darwin_x64, darwin_arm64]
+          file: gitui-mac.tar.gz
+          bin: gitui
+        - target: linux_x64
           file: gitui-linux-musl.tar.gz
           bin: gitui
         - target: linux_arm64

--- a/packages/gitui/package.yaml
+++ b/packages/gitui/package.yaml
@@ -10,10 +10,10 @@ categories: []
 source:
   id: pkg:github/extrawurst/gitui@v0.26.3
   asset:
-    - target: [darwin_arm64]
+    - target: darwin_arm64
       file: gitui-mac.tar.gz
       bin: gitui
-    - target: [darwin_x64]
+    - target: darwin_x64
       file: gitui-mac-x86.tar.gz
       bin: gitui
     - target: linux_x64


### PR DESCRIPTION
## Describe your changes
I've created an issue recently, but I found it's gitui's fault. Their 0.26.2 doesn't work on darwin_x64. #7260

I noticed the upgrading of gitui was failed #5956 , so I upgraded the gitui to 0.26.3 and solved this issue.


## Issue ticket number and link
#7260 
#5956 

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.



## Screenshots
<img width="1109" alt="image" src="https://github.com/user-attachments/assets/f046b862-b18b-478f-8ddd-94f1ba6442d7">
<img width="1404" alt="image" src="https://github.com/user-attachments/assets/98086e5d-d8e5-432f-8dc7-1490138cf8bd">
<img width="1665" alt="image" src="https://github.com/user-attachments/assets/52bfe64b-fc8f-4d69-bd44-6bb582a1f090">



