### PR TITLE
Add support for the `prettydiff` formatter

### DIFF
--- a/packages/prettydiff/package.yaml
+++ b/packages/prettydiff/package.yaml
@@ -1,0 +1,16 @@
+---
+name: prettydiff
+description: Beautifier and language aware code comparison tool for many languages. It also minifies and a few other things.
+homepage: https://github.com/prettydiff/prettydiff
+licenses:
+  - CC0-1.0
+languages:
+  - HTML
+categories:
+  - FORMATTER
+
+source:
+  id: pkg:npm/prettydiff@101.0.0
+
+bin:
+  prettydiff: npm:prettydiff

--- a/packages/prettydiff/package.yaml
+++ b/packages/prettydiff/package.yaml
@@ -7,7 +7,7 @@ licenses:
 languages:
   - HTML
 categories:
-  - FORMATTER
+  - Formatter
 
 source:
   id: pkg:npm/prettydiff@101.0.0


### PR DESCRIPTION
## Describe your changes
This change adds a simple package definition to allow the installation of `prettydiff` via Mason.

Prior to this change, there was no support for the `prettydiff` formatter when using Mason with neovim.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
