### PR TITLE
tweak: add other shells bash-language-server supports

### DIFF
--- a/packages/bash-language-server/package.yaml
+++ b/packages/bash-language-server/package.yaml
@@ -6,6 +6,10 @@ licenses:
   - MIT
 languages:
   - Bash
+  - Csh
+  - Ksh
+  - Sh
+  - Zsh
 categories:
   - LSP
 


### PR DESCRIPTION
## Describe your changes
Add other shells to bash-language-server languages because it would work for other shell configuration files as well.

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
