### PR TITLE
feat: add beanhub-cli

### DIFF
--- a/packages/beanhub-cli/package.yaml
+++ b/packages/beanhub-cli/package.yaml
@@ -1,0 +1,16 @@
+---
+name: beanhub-cli
+description: A simple beancount formatter that keeps comments.
+homepage: https://beanhub-cli-docs.beanhub.io/
+licenses:
+  - MIT
+languages:
+  - Beancount
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/beanhub-cli@1.4.1
+
+bin:
+  bh: pypi:bh


### PR DESCRIPTION
## Describe your changes

This PR adds [beanhub-cli](https://beanhub-cli-docs.beanhub.io/) as a formatter.
Advantages over bean-format: It preserves comments and is able to sort the journal files.

## Issue ticket number and link


## Checklist before requesting a review

- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.


## Screenshots
