### PR TITLE
Add Nextflow language server

### DIFF
--- a/packages/nextflow-language-server/package.yaml
+++ b/packages/nextflow-language-server/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/nextflow-io/language-server@v1.0.0
+  id: pkg:github/nextflow-io/language-server@v24.10.1
   asset:
     file: "language-server-all.jar"
 

--- a/packages/nextflow-language-server/package.yaml
+++ b/packages/nextflow-language-server/package.yaml
@@ -12,9 +12,13 @@ categories:
 
 source:
   # renovate:datasource=git-refs
-  id: pkg:github/nextflow-io/language-server@41686be96eee6148e233989f37be00e847fb63a7
-  build:
-    run: gradle --no-daemon build
+  id: pkg:github/nextflow-io/vscode-language-nextflow@v1.0.0-alpha10
+  asset:
+    # FIXME Talk to Ben about getting v in there?
+    file: nextflow-1.0.0-alpha10.zip
+    bin: extension/bin/language-server-all.jar
 
-bin:
-  nextflow-language-server: java-jar:build/libs/language-server-all.jar
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/nextflow-io/vscode-language-nextflow/{{version}}/package.json
+# bin:
+#   nextflow-language-server: "{{source.asset.bin}}"

--- a/packages/nextflow-language-server/package.yaml
+++ b/packages/nextflow-language-server/package.yaml
@@ -15,7 +15,7 @@ source:
     file: "language-server-all.jar"
 
 schemas:
-  lsp: vscode:https://raw.githubusercontent.com/nextflow-io/vscode-language-nextflow/{{version}}/package.json
+  lsp: vscode:https://raw.githubusercontent.com/nextflow-io/vscode-language-nextflow/main/package.json
 
 bin:
   nextflow-language-server: java-jar:language-server-all.jar

--- a/packages/nextflow-language-server/package.yaml
+++ b/packages/nextflow-language-server/package.yaml
@@ -14,8 +14,7 @@ source:
   # renovate:datasource=git-refs
   id: pkg:github/nextflow-io/vscode-language-nextflow@v1.0.0-alpha10
   asset:
-    # FIXME Talk to Ben about getting v in there?
-    file: nextflow-1.0.0-alpha10.zip
+    file: nextflow-{{ version | strip_prefix "v" }}.zip
     bin: extension/bin/language-server-all.jar
 
 schemas:

--- a/packages/nextflow-language-server/package.yaml
+++ b/packages/nextflow-language-server/package.yaml
@@ -12,12 +12,12 @@ categories:
 
 source:
   # renovate:datasource=git-refs
-  id: pkg:github/nextflow-io/vscode-language-nextflow@v1.0.0-alpha10
+  id: pkg:github/edmundmiller/vscode-language-nextflow@1.0.0
   asset:
-    file: nextflow-{{ version | strip_prefix "v" }}.zip
-    bin: extension/bin/language-server-all.jar
+    file: nextflow-{{ version | strip_prefix "v" }}.vsix
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/nextflow-io/vscode-language-nextflow/{{version}}/package.json
-# bin:
-#   nextflow-language-server: "{{source.asset.bin}}"
+
+bin:
+  nextflow-language-server: java-jar:extension/bin/language-server-all.jar

--- a/packages/nextflow-language-server/package.yaml
+++ b/packages/nextflow-language-server/package.yaml
@@ -3,15 +3,13 @@ name: nextflow-language-server
 description: A language server for Nextflow.
 homepage: https://github.com/nextflow-io/language-server
 licenses:
-  - MIT
+  - Apache-2.0
 languages:
   - Nextflow
-  - Groovy
 categories:
   - LSP
 
 source:
-  # renovate:datasource=git-refs
   id: pkg:github/nextflow-io/language-server@v1.0.0
   asset:
     file: "language-server-all.jar"

--- a/packages/nextflow-language-server/package.yaml
+++ b/packages/nextflow-language-server/package.yaml
@@ -1,23 +1,23 @@
 ---
 name: nextflow-language-server
 description: A language server for Nextflow.
-homepage: https://github.com/nextflow-io/vscode-language-nextflow
+homepage: https://github.com/nextflow-io/language-server
 licenses:
   - MIT
 languages:
-  - nextflow
-  - groovy
+  - Nextflow
+  - Groovy
 categories:
   - LSP
 
 source:
   # renovate:datasource=git-refs
-  id: pkg:github/nextflow-io/vscode-language-nextflow@v1.0.0-rc1
+  id: pkg:github/nextflow-io/language-server@v1.0.0
   asset:
-    file: nextflow-{{ version | strip_prefix "v" }}.vsix
+    file: "language-server-all.jar"
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/nextflow-io/vscode-language-nextflow/{{version}}/package.json
 
 bin:
-  nextflow-language-server: java-jar:extension/bin/language-server-all.jar
+  nextflow-language-server: java-jar:language-server-all.jar

--- a/packages/nextflow-language-server/package.yaml
+++ b/packages/nextflow-language-server/package.yaml
@@ -1,0 +1,20 @@
+---
+name: nextflow-language-server
+description: A language server for Nextflow.
+homepage: https://github.com/nextflow-io/language-server
+licenses:
+  - Apache-2.0
+languages:
+  - nextflow
+  - groovy
+categories:
+  - LSP
+
+source:
+  # renovate:datasource=git-refs
+  id: pkg:github/nextflow-io/language-server@41686be96eee6148e233989f37be00e847fb63a7
+  build:
+    run: gradle --no-daemon build
+
+bin:
+  nextflow-language-server: java-jar:build/libs/language-server-all.jar

--- a/packages/nextflow-language-server/package.yaml
+++ b/packages/nextflow-language-server/package.yaml
@@ -3,7 +3,7 @@ name: nextflow-language-server
 description: A language server for Nextflow.
 homepage: https://github.com/nextflow-io/vscode-language-nextflow
 licenses:
-  - Apache-2.0
+  - MIT
 languages:
   - nextflow
   - groovy

--- a/packages/nextflow-language-server/package.yaml
+++ b/packages/nextflow-language-server/package.yaml
@@ -1,7 +1,7 @@
 ---
 name: nextflow-language-server
 description: A language server for Nextflow.
-homepage: https://github.com/nextflow-io/language-server
+homepage: https://github.com/nextflow-io/vscode-language-nextflow
 licenses:
   - Apache-2.0
 languages:
@@ -12,7 +12,7 @@ categories:
 
 source:
   # renovate:datasource=git-refs
-  id: pkg:github/edmundmiller/vscode-language-nextflow@1.0.0
+  id: pkg:github/nextflow-io/vscode-language-nextflow@v1.0.0-rc1
   asset:
     file: nextflow-{{ version | strip_prefix "v" }}.vsix
 


### PR DESCRIPTION
- **feat: add nextflow-language-server**
- **fix(nextflow): Try going in a different direction**
- **chore(nextflow): Clean up version**
- **fix(nextflow): use vsix instead of zip**
- **chore(nextflow): Update to original repo**

## Describe your changes
<!-- Short description of what has been changed and/or added and why -->

Adds the Nextflow language server that's in the VS Code extension.

Let me know if there's a better way of doing this!

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
