### PR TITLE
updated erlang-ls version from 0.52.0 to 1.0.0

### DIFF
--- a/packages/erlang-ls/package.yaml
+++ b/packages/erlang-ls/package.yaml
@@ -13,7 +13,7 @@ categories:
 
 source:
   # renovate:datasource=github-tags
-  id: pkg:github/erlang-ls/erlang_ls@0.52.0
+  id: pkg:github/erlang-ls/erlang_ls@1.0.0
   build:
     - target: win
       run: |

--- a/packages/erlang-ls/package.yaml
+++ b/packages/erlang-ls/package.yaml
@@ -13,7 +13,7 @@ categories:
 
 source:
   # renovate:datasource=github-tags
-  id: pkg:github/erlang-ls/erlang_ls@1.0.0
+  id: pkg:github/erlang-ls/erlang_ls@1.1.0
   build:
     - target: win
       run: |


### PR DESCRIPTION
Besides being outdated, version 0.52.0 is breaking during the build, as can be seen in the issue https://github.com/erlang-ls/erlang_ls/issues/1532

## Describe your changes
I just updated the erlang-ls version

## Issue ticket number and link
https://github.com/erlang-ls/erlang_ls/issues/1532

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
