### PR TITLE
feat: add nixd

### DIFF
--- a/packages/nixd/package.yaml
+++ b/packages/nixd/package.yaml
@@ -1,0 +1,26 @@
+---
+name: nixd
+description: Language Server for Nix.
+homepage: https://github.com/nix-community/nixd
+licenses:
+  - LGPL-3.0
+languages:
+  - Nix
+categories:
+  - LSP
+
+source:
+  # renovate:datasource=github-tags
+  id: pkg:github/nix-community/nixd@2.4.0
+  build:
+    - target: unix
+      run: |
+        meson -Dprefix="$PWD" build
+        ninja -C build install
+    - target: win
+      run: |
+        meson -Dprefix="($pwd).path" build
+        ninja -C build install
+
+bin:
+  nixd: "${{source.bin}}"


### PR DESCRIPTION
## Describe your changes

Adds the `nixd` LSP at the latest version 2.4.0. The previous PR has become stale.

## Issue ticket number and link

Closes https://github.com/williamboman/mason.nvim/issues/1570

Updates the stale, but already approved PR, https://github.com/mason-org/mason-registry/pull/4822