### PR TITLE
Install terraform-ls on FreeBSD

### DIFF
--- a/packages/terraform-ls/package.yaml
+++ b/packages/terraform-ls/package.yaml
@@ -21,6 +21,10 @@ source:
       files:
         terraform-ls.zip: https://releases.hashicorp.com/terraform-ls/{{ version | strip_prefix "v" }}/terraform-ls_{{ version | strip_prefix "v" }}_darwin_amd64.zip
       bin: terraform-ls
+    - target: freebsd_x64
+      files:
+        terraform-ls.zip: https://releases.hashicorp.com/terraform-ls/{{ version | strip_prefix "v" }}/terraform-ls_{{ version | strip_prefix "v" }}_freebsd_amd64.zip
+      bin: terraform-ls
     - target: linux_arm64
       files:
         terraform-ls.zip: https://releases.hashicorp.com/terraform-ls/{{ version | strip_prefix "v" }}/terraform-ls_{{ version | strip_prefix "v" }}_linux_arm64.zip


### PR DESCRIPTION
Hey,
I'm using Mason via LazyVim on macOS, GNU/Linux and FreeBSD 14.
Various language servers install and works just fine, but for a few I get errors like `The current platform is unsupported.`.
I'm interested in trying to fix the ones that can be fixed, and I'm looking at starting this with terraform-ls.

It turns out that for this one it should in theory be doable and fairly easy as Hashicorp provides packages for terraform-ls on FreeBSD, as an example: https://releases.hashicorp.com/terraform-ls/0.34.3/

I was able to install it by using this repository locally and manually specifying the target:

```shell
:MasonInstall --target=freebsd_x64 terraform-ls
```

Apparently the target is not automatically identified/used, and I'm not sure how/where it should be handled, thanks for your work on Mason and I would welcome any advice regarding how to address this!