### PR TITLE
fix(harper-ls): change filename to `-msvc` from `-gnu`

### DIFF
--- a/packages/harper-ls/package.yaml
+++ b/packages/harper-ls/package.yaml
@@ -17,6 +17,7 @@ languages:
   - C#
   - TOML
   - Lua
+  - Java
 categories:
   - LSP
 
@@ -36,7 +37,7 @@ source:
       file: harper-ls-aarch64-apple-darwin.tar.gz
       bin: harper-ls
     - target: win_x64
-      file: harper-ls-x86_64-pc-windows-gnu.zip
+      file: harper-ls-x86_64-pc-windows-msvc.zip
       bin: harper-ls.exe
 
 bin:

--- a/packages/harper-ls/package.yaml
+++ b/packages/harper-ls/package.yaml
@@ -22,7 +22,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/elijah-potter/harper@v0.11.0
+  id: pkg:github/elijah-potter/harper@v0.12.0
   asset:
     - target: linux_x64_gnu
       file: harper-ls-x86_64-unknown-linux-gnu.tar.gz


### PR DESCRIPTION
## Describe your changes
We've added some additional language support and changed our target compiler architecture. This PR fixes the broken filename and highlights this language support.