### PR TITLE
clangd and yq x86_64 and android compatibility support.

### DIFF
--- a/packages/clangd/package.yaml
+++ b/packages/clangd/package.yaml
@@ -18,7 +18,7 @@ source:
     - target: [darwin_x64, darwin_arm64]
       file: clangd-mac-{{version}}.zip
       bin: clangd_{{version}}/bin/clangd
-    - target: linux_x64_gnu
+    - target: linux_x64
       file: clangd-linux-{{version}}.zip
       bin: clangd_{{version}}/bin/clangd
     - target: win_x64

--- a/packages/yq/package.yaml
+++ b/packages/yq/package.yaml
@@ -17,12 +17,6 @@ source:
     - target: darwin_x64
       file: yq_darwin_amd64.tar.gz
       bin: yq_darwin_amd64
-    - target: linux_x64_gnu
-      file: yq_linux_amd64.tar.gz
-      bin: yq_linux_amd64
-    - target: linux_arm64_gnu
-      file: yq_linux_arm64.tar.gz
-      bin: yq_linux_arm64
     - target: linux_x64_openbsd
       file: yq_openbsd_amd64.tar.gz
       bin: yq_openbsd_amd64
@@ -32,6 +26,12 @@ source:
     - target: linux_x86_openbsd
       file: yq_openbsd_386.tar.gz
       bin: yq_openbsd_386
+    - target: linux_x64
+      file: yq_linux_amd64.tar.gz
+      bin: yq_linux_amd64
+    - target: linux_arm64
+      file: yq_linux_arm64.tar.gz
+      bin: yq_linux_arm64
     - target: win_x64
       file: yq_windows_amd64.exe
       bin: yq_windows_amd64.exe


### PR DESCRIPTION
## Changes
- `clangd` server's target is changed from `linux_x64_gnu` to `linux_x64` to support on `x86_64` and android based PCs.
- `yq` server's targets are changed from `linux_x64_gnu` and `linux_arm64_gnu` to `linux_x64` and `linux_arm64` to support on `x86_64` and android based PCs.
- `yq` server's `gnu` linux distro targets are shifted under `openbsd` targets to kill conflicts.

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.