### PR TITLE
feat: add cppcheck linter

### DIFF
--- a/packages/cppcheck/package.yaml
+++ b/packages/cppcheck/package.yaml
@@ -17,7 +17,7 @@ source:
   build:
     - target: unix
       run: |
-        NVIM_DATA_PATH=$(nvim --headless -c 'lua print(vim.fn.stdpath("data"))' -c 'q' 2>&1)
+        NVIM_DATA_PATH=$(nvim --headless -c "lua print(vim.fn.stdpath('data'))" -c "q" 2>&1)
         PKG_DIR=$NVIM_DATA_PATH/mason/packages/cppcheck
         cmake -S . -B build \
           -DCMAKE_BUILD_TYPE=Release \
@@ -29,12 +29,12 @@ source:
 
     - target: win
       run: |
-        for /f "delims=" %%i in ('nvim --headless -c "lua print(vim.fn.stdpath('data'))" -c q 2^>^&1') do set NVIM_DATA_PATH=%%i
-        set PKG_DIR=%NVIM_DATA_PATH%\mason\packages\cppcheck
-        cmake -S . -B build ^
-          -DCMAKE_BUILD_TYPE=Release ^
-          -DCMAKE_INSTALL_PREFIX=%CD% ^
-          -DFILESDIR=%PKG_DIR%
+        $NVIM_DATA_PATH = (nvim --headless -c "lua print(vim.fn.stdpath('data'))" -c "q" 2>&1 | Select-Object -Last 1)
+        $PKG_DIR = Join-Path $NVIM_DATA_PATH "mason\packages\cppcheck"
+        cmake -S . -B build `
+          -DCMAKE_BUILD_TYPE=Release `
+          -DCMAKE_INSTALL_PREFIX="$PWD" `
+          -DFILESDIR="$PKG_DIR"
         cmake --build build
         cmake --install build
       bin: bin\cppcheck.exe

--- a/packages/cppcheck/package.yaml
+++ b/packages/cppcheck/package.yaml
@@ -13,7 +13,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:github/danmar/cppcheck@2.15.0
+  id: pkg:github/danmar/cppcheck@2.16.0
   build:
     - target: unix
       run: |

--- a/packages/cppcheck/package.yaml
+++ b/packages/cppcheck/package.yaml
@@ -35,8 +35,8 @@ source:
           -DCMAKE_BUILD_TYPE=Release `
           -DCMAKE_INSTALL_PREFIX="$PWD" `
           -DFILESDIR="$PKG_DIR"
-        cmake --build build
-        cmake --install build
+        cmake --build build --config Release
+        cmake --install build --config Release
       bin: bin\cppcheck.exe
 
 bin:

--- a/packages/cppcheck/package.yaml
+++ b/packages/cppcheck/package.yaml
@@ -29,7 +29,6 @@ source:
 
     - target: win
       run: |
-        @echo off
         for /f "delims=" %%i in ('nvim --headless -c "lua print(vim.fn.stdpath('data'))" -c q 2^>^&1') do set NVIM_DATA_PATH=%%i
         set PKG_DIR=%NVIM_DATA_PATH%\mason\packages\cppcheck
         cmake -S . -B build ^

--- a/packages/cppcheck/package.yaml
+++ b/packages/cppcheck/package.yaml
@@ -1,0 +1,44 @@
+---
+name: cppcheck
+description: |
+  Static analysis tool for C/C++ code. It provides unique code analysis to detect
+  bugs and focuses on detecting undefined behaviour and dangerous coding constructs.
+homepage: https://github.com/danmar/cppcheck
+licenses:
+  - GPL-3.0-only
+languages:
+  - C
+  - C++
+categories:
+  - Linter
+
+source:
+  id: pkg:github/danmar/cppcheck@2.15.0
+  build:
+    - target: unix
+      run: |
+        NVIM_DATA_PATH=$(nvim --headless -c 'lua print(vim.fn.stdpath("data"))' -c 'q' 2>&1)
+        PKG_DIR=$NVIM_DATA_PATH/mason/packages/cppcheck
+        cmake -S . -B build \
+          -DCMAKE_BUILD_TYPE=Release \
+          -DCMAKE_INSTALL_PREFIX=$PWD \
+          -DFILESDIR=$PKG_DIR
+        cmake --build build
+        cmake --install build
+      bin: bin/cppcheck
+
+    - target: win
+      run: |
+        @echo off
+        for /f "delims=" %%i in ('nvim --headless -c "lua print(vim.fn.stdpath('data'))" -c q 2^>^&1') do set NVIM_DATA_PATH=%%i
+        set PKG_DIR=%NVIM_DATA_PATH%\mason\packages\cppcheck
+        cmake -S . -B build ^
+          -DCMAKE_BUILD_TYPE=Release ^
+          -DCMAKE_INSTALL_PREFIX=%CD% ^
+          -DFILESDIR=%PKG_DIR%
+        cmake --build build
+        cmake --install build
+      bin: bin\cppcheck.exe
+
+bin:
+  cppcheck: "{{ source.build.bin }}"


### PR DESCRIPTION
## Describe your changes
Hi, I saw that [cppcheck](https://cppcheck.sourceforge.io/) was missing from Mason registry so I wanted to add that in.

It has the following build config:
- default release build
- does not support custom "rules" feature (using regex)
  - rules feature requires external dependency on [PCRE](https://www.pcre.org/) package

## Issue ticket number and link
Explicitly using `-DFILESDIR` build flag to workaround issue: https://github.com/danmar/cppcheck/pull/6764

## Checklist before requesting a review
- [x] I have successfully tested installation of the package from local `mason-registry`
- [x] I have successfully tested the package after installation using `nvim-lint`

## Screenshots
<img width="3008" alt="cppcheck_nvim-lint_test" src="https://github.com/user-attachments/assets/02908c28-cf6d-4e82-b005-d7318a1632cc">

