### PR TITLE
feat(texlab): add vscode lsp schema

### DIFF
--- a/packages/texlab/package.yaml
+++ b/packages/texlab/package.yaml
@@ -28,5 +28,8 @@ source:
       file: texlab-x86_64-windows.zip
       bin: texlab.exe
 
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/latex-lsp/texlab-vscode/{{version}}/package.json
+
 bin:
   texlab: "{{source.asset.bin}}"


### PR DESCRIPTION
## Describe your changes
Adds vscode lsp schema to texlab. The versions of the vscode extension and the lsp server are in sync, usually only 20-30 minutes apart and they also have the same versioning.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
