### PR TITLE
Fix Odin language server `ols` for windows hosts

### DIFF
--- a/packages/ols/package.yaml
+++ b/packages/ols/package.yaml
@@ -18,11 +18,8 @@ source:
     - target: linux_x64_gnu
       file: ols-x86_64-unknown-linux-gnu
       bin: ols-x86_64-unknown-linux-gnu
-    - target: win_x86
-      file: ols-x86_64-pc-windows-msvc.exe
-      bin: ols-x86_64-pc-windows-msvc.exe
     - target: win_x64
-      file: ols-x86_64-pc-windows-msvc.exe
+      file: ols-x86_64-pc-windows-msvc.zip
       bin: ols-x86_64-pc-windows-msvc.exe
 
 bin:


### PR DESCRIPTION
## Describe your changes
The installation of the Odin language server (`ols`) on win_x64 hosts is failing due to misconfiguration. Likely due to `ols` changing its packaging format.

- The win_x64 release was incorrectly pointing to a .exe file. Changed to the correct .zip as can be verified [here](https://github.com/DanielGavin/ols/releases/tag/nightly)
- Removed the unsupported win_x86 target

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
