### PR TITLE
feat(remark-ls): add vscode lsp schema

### DIFF
--- a/packages/remark-language-server/package.yaml
+++ b/packages/remark-language-server/package.yaml
@@ -12,5 +12,8 @@ categories:
 source:
   id: pkg:npm/remark-language-server@3.0.0
 
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/remarkjs/vscode-remark/{{version}}/package.json
+
 bin:
   remark-language-server: npm:remark-language-server


### PR DESCRIPTION
## Describe your changes
Adds vscode lsp schema to remark ls. The versions between the vscode repo and the language server are identical though only a few days apart with the vscode extenstion being the first.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
