### PR TITLE
fix(stylua): changed release asset names starting with v2.0.0

### DIFF
--- a/packages/basics-language-server/package.yaml
+++ b/packages/basics-language-server/package.yaml
@@ -1,0 +1,15 @@
+---
+name: basics-language-server
+description: Buffer, path, and snippet completions
+homepage: https://github.com/antonk52/basics-language-server
+licenses:
+  - MIT
+languages: [] # all languages
+categories:
+  - LSP
+
+source:
+  id: pkg:npm/basics-language-server@1.0.1
+
+bin:
+  basics-language-server: npm:basics-language-server

--- a/packages/basics-language-server/package.yaml
+++ b/packages/basics-language-server/package.yaml
@@ -11,5 +11,8 @@ categories:
 source:
   id: pkg:npm/basics-language-server@1.0.1
 
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/antonk52/basics-language-server/refs/heads/main/package.json
+
 bin:
   basics-language-server: npm:basics-language-server

--- a/packages/basics-language-server/package.yaml
+++ b/packages/basics-language-server/package.yaml
@@ -9,10 +9,10 @@ categories:
   - LSP
 
 source:
-  id: pkg:npm/basics-language-server@1.0.1
+  id: pkg:npm/basics-language-server@1.0.2
 
 schemas:
-  lsp: vscode:https://raw.githubusercontent.com/antonk52/basics-language-server/refs/heads/main/package.json
+  lsp: vscode:https://raw.githubusercontent.com/antonk52/basics-language-server/v{{version}}/package.json
 
 bin:
   basics-language-server: npm:basics-language-server


### PR DESCRIPTION
## Describe your changes
changed release asset names starting with v2.0.0

see 'Breaking Changes' section at https://github.com/JohnnyMorganz/StyLua/releases/tag/v2.0.0

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

