### PR TITLE
fix(stylua): adapt to new release asset names starting with v2.0.0

### DIFF
--- a/packages/stylua/package.yaml
+++ b/packages/stylua/package.yaml
@@ -11,13 +11,13 @@ categories:
   - Formatter
 
 source:
-  id: pkg:github/johnnymorganz/stylua@v0.20.0
+  id: pkg:github/johnnymorganz/stylua@v2.0.0
   asset:
     - target: darwin_arm64
       file: stylua-macos-aarch64.zip
       bin: stylua
     - target: darwin_x64
-      file: stylua-macos.zip
+      file: stylua-macos-x86_64.zip
       bin: stylua
     - target: linux_x64_gnu
       file: stylua-linux-x86_64.zip
@@ -29,10 +29,31 @@ source:
       file: stylua-linux-x86_64-musl.zip
       bin: stylua
     - target: win_x64
-      file: stylua-win64.zip
+      file: stylua-windows-x86_64.zip
       bin: stylua.exe
 
   version_overrides:
+    - constraint: semver:<=v0.20.0
+      id: pkg:github/johnnymorganz/stylua@v0.20.0
+      asset:
+      - target: darwin_arm64
+        file: stylua-macos-aarch64.zip
+        bin: stylua
+      - target: darwin_x64
+        file: stylua-macos.zip
+        bin: stylua
+      - target: linux_x64_gnu
+        file: stylua-linux-x86_64.zip
+        bin: stylua
+      - target: linux_arm64_gnu
+        file: stylua-linux-aarch64.zip
+        bin: stylua
+      - target: linux_x64
+        file: stylua-linux-x86_64-musl.zip
+        bin: stylua
+      - target: win_x64
+        file: stylua-win64.zip
+        bin: stylua.exe
     - constraint: semver:<=v0.19.1
       id: pkg:github/johnnymorganz/stylua@v0.19.1
       asset:


### PR DESCRIPTION
## Describe your changes
changed release asset names starting with v2.0.0

see the "Breaking Changes" section at https://github.com/JohnnyMorganz/StyLua/releases/tag/v2.0.0

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

