### PR TITLE
feat: ltex-ls-plus

### DIFF
--- a/packages/ltex-ls-plus/package.yaml
+++ b/packages/ltex-ls-plus/package.yaml
@@ -1,0 +1,44 @@
+---
+name: ltex-ls-plus
+description: |
+  LTeX Language Server+: LSP language server for LanguageTool 🔍✔️ with support for LaTeX 🎓, Markdown 📝, and others.
+homepage: https://ltex-plus.github.io/ltex-plus/
+licenses:
+  - MPL-2.0
+languages:
+  - Text
+  - Markdown
+  - LaTeX
+  - reStructuredText
+categories:
+  - LSP
+
+source:
+  id: pkg:github/ltex-plus/ltex-ls-plus@18.2.0
+  asset:
+    # The platform-specific releases bundle a java runtime engine, and are
+    # therefore preferable to avoid external dependencies (see #2837).
+    - target: darwin
+      file: ltex-ls-plus-{{version}}-mac-x64.tar.gz
+      bin:
+        lsp: ltex-ls-plus-{{version}}/bin/ltex-ls-plus
+        cli: ltex-ls-plus-{{version}}/bin/ltex-cli-plus
+    - target: win
+      file: ltex-ls-plus-{{version}}-windows-x64.zip
+      bin:
+        lsp: ltex-ls-plus-{{version}}/bin/ltex-ls-plus.bat
+        cli: ltex-ls-plus-{{version}}/bin/ltex-cli-plus.bat
+    # using platform-independent release to support linux arm64
+    # (see https://github.com/mason-org/mason-registry/pull/2837#pullrequestreview-1686482498)
+    - target: linux
+      file: ltex-ls-plus-{{version}}.tar.gz
+      bin:
+        lsp: ltex-ls-plus-{{version}}/bin/ltex-ls-plus
+        cli: ltex-ls-plus-{{version}}/bin/ltex-cli-plus
+
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/ltex-plus/vscode-ltex-plus/develop/package.json
+
+bin:
+  ltex-ls-plus: "{{source.asset.bin.lsp}}"
+  ltex-cli-plus: "{{source.asset.bin.cli}}"

--- a/packages/ltex-ls-plus/package.yaml
+++ b/packages/ltex-ls-plus/package.yaml
@@ -14,22 +14,41 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/ltex-plus/ltex-ls-plus@18.2.0
+  id: pkg:github/ltex-plus/ltex-ls-plus@18.4.0
   asset:
     # The platform-specific releases bundle a java runtime engine, and are
     # therefore preferable to avoid external dependencies (see #2837).
-    - target: darwin
+    - target: linux_arm64_gnu
+      file: ltex-ls-plus-{{version}}-linux_aarch64.tar.gz
+      bin:
+        lsp: ltex-ls-plus-{{version}}/bin/ltex-ls-plus
+        cli: ltex-ls-plus-{{version}}/bin/ltex-cli-plus
+    - target: linux_x64_gnu
+      file: ltex-ls-plus-{{version}}-linux-x64.tar.gz
+      bin:
+        lsp: ltex-ls-plus-{{version}}/bin/ltex-ls-plus
+        cli: ltex-ls-plus-{{version}}/bin/ltex-cli-plus
+    - target: darwin_arm64
+      file: ltex-ls-plus-{{version}}-mac-aarch64.tar.gz
+      bin:
+        lsp: ltex-ls-plus-{{version}}/bin/ltex-ls-plus
+        cli: ltex-ls-plus-{{version}}/bin/ltex-cli-plus
+    - target: darwin_x64
       file: ltex-ls-plus-{{version}}-mac-x64.tar.gz
       bin:
         lsp: ltex-ls-plus-{{version}}/bin/ltex-ls-plus
         cli: ltex-ls-plus-{{version}}/bin/ltex-cli-plus
-    - target: win
+    - target: win_x64
       file: ltex-ls-plus-{{version}}-windows-x64.zip
       bin:
         lsp: ltex-ls-plus-{{version}}/bin/ltex-ls-plus.bat
         cli: ltex-ls-plus-{{version}}/bin/ltex-cli-plus.bat
-    # using platform-independent release to support linux arm64
-    # (see https://github.com/mason-org/mason-registry/pull/2837#pullrequestreview-1686482498)
+    - target: win_arm64
+      file: ltex-ls-plus-{{version}}-windows-aarch64.zip
+      bin:
+        lsp: ltex-ls-plus-{{version}}/bin/ltex-ls-plus.bat
+        cli: ltex-ls-plus-{{version}}/bin/ltex-cli-plus.bat
+    # using platform-independent release to support non-gnu linux
     - target: linux
       file: ltex-ls-plus-{{version}}.tar.gz
       bin:


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Added [ltex-ls-plus](https://github.com/ltex-plus/ltex-ls-plus), fork of [ltex-ls](https://github.com/mason-org/mason-registry/blob/e10d4c0b60320b216e1920cb4d36fd5be4ae1b79/packages/ltex-ls/package.yaml) (already on the registry). Unlike the upstream project, ltex-ls-plus is actively maintained. Not sure how many Neovim users are out there, but the VSCode extention has over 4700 installs.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
![Screenshot of the Mason window stating ltex-ls-plus has been installed successfully](https://github.com/user-attachments/assets/c2ecdc1d-601b-4f0a-a476-117c536cd2e9)
![ltex-plus-ls reporting some errors in a LaTeX document](https://github.com/user-attachments/assets/1250ce2d-8eea-4764-ab00-6c32ea4631e3)
