### PR TITLE
feat: add gdtoolkit3

### DIFF
--- a/packages/gdtoolkit3/package.yaml
+++ b/packages/gdtoolkit3/package.yaml
@@ -1,0 +1,18 @@
+---
+name: gdtoolkit3
+description: A set of tools for daily work with GDScript for Godot 3.
+homepage: https://github.com/Scony/godot-gdscript-toolkit
+licenses:
+  - MIT
+languages:
+  - GDScript
+categories:
+  - Linter
+  - Formatter
+
+source:
+  id: pkg:pypi/gdtoolkit@3.6.0
+
+bin:
+  gdlint: pypi:gdlint
+  gdformat: pypi:gdformat


### PR DESCRIPTION
## Describe your changes
This PR adds a `gdtoolkit3` package which specifically is intendend to use for Godot 3 only. The already existing [`gdtoolkit`](https://github.com/mason-org/mason-registry/tree/main/packages/gdtoolkit) package only delivers tools for Godot 4 which do not work with Godot 3


I coudn't figure out if i can somehow reuse the same `gdtoolkit` package and define both versions in it without pretty much just duplicating the existing one :)

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

## Screenshots
