### PR TITLE
Feat: Adds Duster as a PHP Formatter/Linter Option

### DIFF
--- a/packages/duster/package.yaml
+++ b/packages/duster/package.yaml
@@ -1,0 +1,18 @@
+---
+name: duster
+description: Automatic configuration for Laravel apps to apply Tighten's standard linting & code standards.
+homepage: https://github.com/tighten/duster
+licenses:
+  - MIT
+languages:
+  - PHP
+  - Blade
+categories:
+  - Formatter
+  - Linter
+
+source:
+  id: pkg:composer/tightenco/duster@v3.0.3
+
+bin:
+  duster: composer:duster


### PR DESCRIPTION
## Describe your changes
[Duster](https://github.com/tighten/duster) combines different PHP formatters and linters and runs them all simultaneously. It should work similarly to [Pint](https://github.com/mason-org/mason-registry/blob/main/packages/pint/package.yaml), [PHPCS](https://github.com/mason-org/mason-registry/blob/main/packages/phpcs/package.yaml), or [PHP-CS-Fixer](https://github.com/mason-org/mason-registry/blob/main/packages/php-cs-fixer/package.yaml) (since it wraps those packages).

## Issue ticket number and link

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots

