### PR TITLE
feat: add VSCode Spring Boot Tools

### DIFF
--- a/packages/vscode-spring-boot-tools/package.yaml
+++ b/packages/vscode-spring-boot-tools/package.yaml
@@ -1,0 +1,26 @@
+---
+name: vscode-spring-boot-tools
+description: |
+  VS Code Language Server for Spring Boot
+  VSCode extension and Language Server providing support for working with Spring Boot application.properties, application.yml and .java files.
+
+  Note: this extension has a dependency on VS Code extension of Language Support for Java™ by Red Hat.
+homepage: https://github.com/spring-projects/sts4
+licenses:
+  - EPL-1.0
+languages:
+  - Java
+categories:
+  - LSP
+
+source:
+  id: pkg:openvsx/VMware/vscode-spring-boot@1.58.0
+  download:
+    file: VMware.vscode-spring-boot-{{version}}.vsix
+
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/spring-projects/sts4/master/vscode-extensions/vscode-spring-boot/package.json
+
+share:
+  vscode-spring-boot-tools/jdtls/: extension/jars/
+  vscode-spring-boot-tools/language-server.jar: extension/language-server/spring-boot-language-server-{{version}}-SNAPSHOT-exec.jar


### PR DESCRIPTION
## Describe your changes
Added Spring Boot Tools, providing support for working with Spring Boot application.properties, application.yml and .java files.

[Spring Boot Tools in Open VSX registry](https://open-vsx.org/extension/VMware/vscode-spring-boot)

## Issue ticket number and link

## Checklist before requesting a review
- [ x ] I have successfully tested installation of the package.
- [ x ] I have successfully tested the package after installation.
      
## Screenshots
