### PR TITLE
fix(helm-ls): set arm target to linux_arm64

### DIFF
--- a/packages/helm-ls/package.yaml
+++ b/packages/helm-ls/package.yaml
@@ -18,7 +18,7 @@ source:
       file: helm_ls_darwin_arm64
     - target: linux_x64_gnu
       file: helm_ls_linux_amd64
-    - target: linux_arm
+    - target: linux_arm64
       file: helm_ls_linux_arm
     - target: win_x64
       file: helm_ls_windows_amd64.exe


### PR DESCRIPTION
## Describe your changes

<!-- Short description of what has been changed and/or added and why -->

The binary is actually an arm64 binary, but the platform doesn't get recognized correctly.

## Issue ticket number and link

<!-- Leave empty if not available -->

## Checklist before requesting a review

<!-- Refer to the CONTRIBUTING.md for details on testing -->

- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
          diagnostics -->

## Screenshots

<!-- Leave empty if not applicable -->
