### PR TITLE
Add kube-linter

### DIFF
--- a/packages/kube-linter/package.yaml
+++ b/packages/kube-linter/package.yaml
@@ -1,0 +1,34 @@
+---
+name: kube-linter
+description: |
+  KubeLinter is a static analysis tool that checks Kubernetes YAML files and Helm charts to ensure the applications represented in them adhere to best practices.
+homepage: https://docs.kubelinter.io
+licenses:
+  - Apache-2.0
+languages:
+  - Helm
+  - YAML
+categories:
+  - Linter
+
+source:
+  id: pkg:github/stackrox/kube-linter@v0.7.1
+  asset:
+    - target: darwin_x64
+      file: kube-linter-darwin.tar.gz
+      bin: kube-linter
+    - target: darwin_arm64
+      file: kube-linter-darwin_arm64.tar.gz
+      bin: kube-linter
+    - target: linux_x64
+      file: kube-linter-linux.tar.gz
+      bin: kube-linter
+    - target: linux_arm64
+      file: kube-linter-linux_arm64.tar.gz
+      bin: kube-linter
+    - target: win_x64
+      file: kube-linter-windows.tar.gz
+      bin: kube-linter.exe
+
+bin:
+  kube-linter: "{{source.asset.bin}}"

--- a/packages/kube-linter/package.yaml
+++ b/packages/kube-linter/package.yaml
@@ -12,7 +12,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:github/stackrox/kube-linter@v0.7.1
+  id: pkg:github/stackrox/kube-linter@v0.7.2
   asset:
     - target: darwin_x64
       file: kube-linter-darwin.tar.gz


### PR DESCRIPTION
## Describe your changes

KubeLinter analyzes Kubernetes YAML files and Helm charts and checks them against various best practices, with a focus on production readiness and security.

This PR adds the kube-linter package to the mason registry.

## Issue ticket number and link


## Checklist before requesting a review

- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.


## Screenshots

![Screenshot 2024-12-05 at 09 26 47](https://github.com/user-attachments/assets/0ff6008c-f5f4-44cd-983c-5db8d4ca78d9)
![Screenshot 2024-12-05 at 09 26 28](https://github.com/user-attachments/assets/d89211f1-b663-4a3d-9353-397fa63de5d6)