### PR TITLE
bump(java-debug-adapter): update to 0.58.1

### DIFF
--- a/packages/java-debug-adapter/package.yaml
+++ b/packages/java-debug-adapter/package.yaml
@@ -16,4 +16,4 @@ source:
 
 share:
   java-debug-adapter/: extension/server/
-  java-debug-adapter/com.microsoft.java.debug.plugin.jar: extension/server/com.microsoft.java.debug.plugin-0.53.0.jar
+  java-debug-adapter/com.microsoft.java.debug.plugin.jar: extension/server/com.microsoft.java.debug.plugin-0.53.1.jar

--- a/packages/java-debug-adapter/package.yaml
+++ b/packages/java-debug-adapter/package.yaml
@@ -10,7 +10,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:openvsx/vscjava/vscode-java-debug@0.58.0
+  id: pkg:openvsx/vscjava/vscode-java-debug@0.58.1
   download:
     file: vscjava.vscode-java-debug-{{version}}.vsix
 


### PR DESCRIPTION
Beep boop. I've updated java-debug-adapter to 0.58.1.

<sup>` 🤖 This is an automated comment. `</sup>
