### PR TITLE
feat: Add nomad and terraform

### DIFF
--- a/packages/nomad/package.yaml
+++ b/packages/nomad/package.yaml
@@ -1,0 +1,41 @@
+---
+name: nomad
+description: |
+  Nomad is an easy-to-use, flexible, and performant workload orchestrator that can deploy a mix of microservice,
+  batch, containerized, and non-containerized applications. Nomad is easy to operate and scale and has native Consul
+  and Vault integrations.
+homepage: https://www.nomadproject.io/
+licenses:
+  - BUSL-1.1
+languages:
+  - Nomad
+categories:
+  - Formatter
+
+source:
+  # renovate:datasource=github-releases
+  id: pkg:generic/hashicorp/nomad@v1.9.4
+  download:
+    - target: darwin_x64
+      files:
+        nomad.zip: https://releases.hashicorp.com/nomad/{{ version | strip_prefix "v" }}/nomad_{{ version | strip_prefix "v" }}_darwin_amd64.zip
+      bin: nomad
+    - target: darwin_arm64
+      files:
+        nomad.zip: https://releases.hashicorp.com/nomad/{{ version | strip_prefix "v" }}/nomad_{{ version | strip_prefix "v" }}_darwin_arm64.zip
+      bin: nomad
+    - target: linux_x64
+      files:
+        nomad.zip: https://releases.hashicorp.com/nomad/{{ version | strip_prefix "v" }}/nomad_{{ version | strip_prefix "v" }}_linux_amd64.zip
+      bin: nomad
+    - target: linux_arm64
+      files:
+        nomad.zip: https://releases.hashicorp.com/nomad/{{ version | strip_prefix "v" }}/nomad_{{ version | strip_prefix "v" }}_linux_arm64.zip
+      bin: nomad
+    - target: win_x64
+      files:
+        nomad: https://releases.hashicorp.com/nomad/{{ version | strip_prefix "v" }}/nomad_{{ version | strip_prefix "v" }}_windows_amd64.zip
+      bin: nomad
+
+bin:
+  nomad: "{{source.download.bin}}"

--- a/packages/terraform/package.yaml
+++ b/packages/terraform/package.yaml
@@ -1,0 +1,53 @@
+---
+name: terraform
+description: |
+  Terraform enables you to safely and predictably create, change, and improve infrastructure. It is a source-available
+  tool that codifies APIs into declarative configuration files that can be shared amongst team members, treated as code,
+  edited, reviewed, and versioned.
+homepage: https://www.terraform.io/
+licenses:
+  - BUSL-1.1
+languages:
+  - Terraform
+categories:
+  - Formatter
+
+source:
+  # renovate:datasource=github-releases
+  id: pkg:generic/hashicorp/terraform@v1.10.3
+  download:
+    - target: darwin_arm64
+      files:
+        terraform.zip: https://releases.hashicorp.com/terraform/{{ version | strip_prefix "v" }}/terraform_{{ version | strip_prefix "v" }}_darwin_arm64.zip
+      bin: terraform
+    - target: darwin_x64
+      files:
+        terraform.zip: https://releases.hashicorp.com/terraform/{{ version | strip_prefix "v" }}/terraform_{{ version | strip_prefix "v" }}_darwin_amd64.zip
+      bin: terraform
+    - target: linux_arm64
+      files:
+        terraform.zip: https://releases.hashicorp.com/terraform/{{ version | strip_prefix "v" }}/terraform_{{ version | strip_prefix "v" }}_linux_arm64.zip
+      bin: terraform
+    - target: linux_arm
+      files:
+        terraform.zip: https://releases.hashicorp.com/terraform/{{ version | strip_prefix "v" }}/terraform_{{ version | strip_prefix "v" }}_linux_arm.zip
+      bin: terraform
+    - target: linux_x64
+      files:
+        terraform.zip: https://releases.hashicorp.com/terraform/{{ version | strip_prefix "v" }}/terraform_{{ version | strip_prefix "v" }}_linux_amd64.zip
+      bin: terraform
+    - target: linux_x86
+      files:
+        terraform.zip: https://releases.hashicorp.com/terraform/{{ version | strip_prefix "v" }}/terraform_{{ version | strip_prefix "v" }}_linux_386.zip
+      bin: terraform
+    - target: win_x64
+      files:
+        terraform.zip: https://releases.hashicorp.com/terraform/{{ version | strip_prefix "v" }}/terraform_{{ version | strip_prefix "v" }}_windows_amd64.zip
+      bin: terraform.exe
+    - target: win_x86
+      files:
+        terraform.zip: https://releases.hashicorp.com/terraform/{{ version | strip_prefix "v" }}/terraform_{{ version | strip_prefix "v" }}_windows_386.zip
+      bin: terraform.exe
+
+bin:
+  terraform: "{{source.download.bin}}"


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Added nomad and terraform, two Hashicorp tools that come with built-in `fmt` commands for files of their type. 

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
<img width="766" alt="image" src="https://github.com/user-attachments/assets/856136ed-ef7b-47b0-b385-3131ca172216" />

<img width="435" alt="image" src="https://github.com/user-attachments/assets/41ba78f9-1200-4fc5-b691-9e098ebc00ee" />

<img width="375" alt="image" src="https://github.com/user-attachments/assets/d5bd3037-cbfe-479f-a32e-01ac9c9644c8" />

