### PR TITLE
Add ARM64 build of elp

### DIFF
--- a/packages/elp/package.yaml
+++ b/packages/elp/package.yaml
@@ -18,6 +18,9 @@ source:
     - target: linux_x64_gnu
       file: elp-linux-x86_64-unknown-linux-gnu-otp-26.2.tar.gz
       bin: elp
+    - target: linux_arm64_gnu
+      file: elp-linux-aarch64-unknown-linux-gnu-otp-26.2.tar.gz
+      bin: elp
     - target: darwin_x64
       file: elp-macos-x86_64-apple-darwin-otp-26.2.tar.gz
       bin: elp


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Upstream provides Linux arm64 builds, this adds them to the `package.yaml`.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
