### PR TITLE
feat: add `lua-3p-language-servers`

### DIFF
--- a/packages/lua-3p-language-servers/package.yaml
+++ b/packages/lua-3p-language-servers/package.yaml
@@ -1,0 +1,19 @@
+# using my own package config PENDING https://github.com/mason-org/mason-registry/pull/7957
+---
+name: lua-3p-language-servers
+description: 3rd party language servers for selene and stylua
+homepage: https://github.com/antonk52/lua-3p-language-servers # also https://www.npmjs.com/package/lua-3p-language-servers
+licenses:
+  - MIT
+languages:
+  - Lua
+  - Luau
+categories:
+  - LSP
+
+source:
+  id: pkg:npm/lua-3p-language-servers@1.0.0
+
+bin:
+  selene-3p-language-server: npm:selene-3p-language-server
+  stylua-3p-language-server: npm:stylua-3p-language-server


### PR DESCRIPTION
This language server wraps `selene` and `stylua`, making them both available in nvim without the use of an intermediary plugin like `conform` or an intermediary LSP like `efm`.

https://github.com/antonk52/lua-3p-language-servers

## Issue ticket number and link
https://github.com/JohnnyMorganz/StyLua/issues/936

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

