### PR TITLE
feat: add kos-language-server

### DIFF
--- a/packages/kos-language-server/package.yaml
+++ b/packages/kos-language-server/package.yaml
@@ -1,0 +1,21 @@
+---
+name: kos-language-server
+description: Language Server for Kerboscript from the kOS Kerbal Space Program mod.
+homepage: https://github.com/jonnyboyC/kos-language-server
+licenses:
+  - MIT
+languages:
+  - Kerboscript
+categories:
+  - LSP
+  - Linter
+  - Formatter
+
+source:
+  id: pkg:npm/kos-language-server@1.1.5
+
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/jonnyboyC/kos-language-server/refs/heads/main/package.json
+
+bin:
+  kls: npm:kls


### PR DESCRIPTION
## Describe your changes
Adding the kos-language-server for Kerboscript, the language used by the Kerbal Space Program mod kOS.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x ] I have successfully tested installation of the package.
- [x ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
![image](https://github.com/user-attachments/assets/05c4566c-9905-4d7e-8b15-231b47bd155e)
