### PR TITLE
bump(helm-ls): update to 0.2.0 and add linux_arm64

### DIFF
--- a/packages/helm-ls/package.yaml
+++ b/packages/helm-ls/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/mrjosh/helm-ls@v0.1.1
+  id: pkg:github/mrjosh/helm-ls@v0.2.0
   asset:
     - target: darwin_x64
       file: helm_ls_darwin_amd64
@@ -20,6 +20,8 @@ source:
       file: helm_ls_linux_amd64
     - target: linux_arm
       file: helm_ls_linux_arm
+    - target: linux_arm64
+      file: helm_ls_linux_arm64
     - target: win_x64
       file: helm_ls_windows_amd64.exe
 


### PR DESCRIPTION

## Describe your changes
<!-- Short description of what has been changed and/or added and why -->

Bump helm-ls and add the linux_arm64 target, which was added/fixed in https://github.com/mrjosh/helm-ls/pull/124

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
