### PR TITLE
Update `nimlangserver` package name for semver==1.8.0

### DIFF
--- a/packages/nimlangserver/package.yaml
+++ b/packages/nimlangserver/package.yaml
@@ -31,5 +31,25 @@ source:
       file: nimlangserver-{{ version | strip_prefix "v" }}-windows-amd64.zip
       bin: nimlangserver.exe
 
+  version_overrides:
+    - constraint: semver:>=v1.8.0
+      id: pkg:github/nim-lang/langserver@v1.8.0
+      asset:
+        - target: linux_x64
+          file: nimlangserver-linux-amd64.tar.gz
+          bin: nimlangserver
+        - target: linux_arm64
+          file: nimlangserver-linux-arm64.tar.gz
+          bin: nimlangserver
+        - target: darwin_x64
+          file: nimlangserver-macos-amd64.zip
+          bin: nimlangserver
+        - target: darwin_arm64
+          file: nimlangserver-macos-arm64.zip
+          bin: nimlangserver
+        - target: win_x64
+          file: nimlangserver-windows-amd64.zip
+          bin: nimlangserver.exe
+
 bin:
   nimlangserver: "{{source.asset.bin}}"


### PR DESCRIPTION
## Describe your changes
Nim's [`nimlangserver`](https://github.com/nim-lang/langserver/releases) LSP in latest version (1.8.0) removed the version from its tar.gz file name. I removed that for versions >= 1.8.0. I tested both 1.8.0 and 1.6.0 versions and they seem to work (installation and the LSP itself).

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
