### PR TITLE
feat: Autohotkey LSP

### DIFF
--- a/packages/autohotkey_lsp/package.yaml
+++ b/packages/autohotkey_lsp/package.yaml
@@ -1,0 +1,24 @@
+---
+name: autohotkey_lsp
+description: AutoHotkey v2 language support
+homepage: https://github.com/thqby/vscode-autohotkey2-lsp
+licenses:
+  - LGPL-3.0
+languages:
+  - AutoHotkey
+categories:
+  - LSP
+
+source:
+  # renovate:datasource=git-refs
+  id: pkg:github/thqby/vscode-autohotkey2-lsp@2f6de3c75ce91054b0ace0c0bc39001a4ff9e017
+  build:
+    - target: win
+      run: |
+        Remove-Item .npmrc
+        Remove-Item package-lock.json
+        npm install
+        node esbuild.mjs
+
+bin:
+  autohotkey_lsp: node:server/dist/server.js


### PR DESCRIPTION
The AutoHotkey project is only for windows environment.

Cleaned the yaml file and updated to the latest stable commit

## Describe your changes
Adding support for the autohotkey language server.

The https://github.com/neovim/nvim-lspconfig/pull/3408 (autohotkey_lsp) has been added to the nvim-lspconfig, this is a relation to this :)

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->
      You can check the vscode-autohotkey2-lsp on the visual studio code plugins.

## Screenshots
<!-- Leave empty if not applicable -->