### PR TITLE
bump(ocaml-lsp): update to v1.22.0

### DIFF
--- a/packages/ocaml-lsp/package.yaml
+++ b/packages/ocaml-lsp/package.yaml
@@ -10,6 +10,6 @@ categories:
   - LSP
 
 source:
-  id: pkg:opam/ocaml-lsp-server@1.19.0
+  id: pkg:opam/ocaml-lsp-server@1.22.0
 bin:
   ocamllsp: opam:ocamllsp


### PR DESCRIPTION
Updated the ocaml-lsp because the old version fails to install for latest Ocaml, v5.3.0