### PR TITLE
bump(ocamlformat): update to v.0.27.0

### DIFF
--- a/packages/ocamlformat/package.yaml
+++ b/packages/ocamlformat/package.yaml
@@ -12,7 +12,7 @@ categories:
   - Formatter
 
 source:
-  id: pkg:opam/ocamlformat@0.26.2
+  id: pkg:opam/ocamlformat@0.27.0
 
 bin:
   ocamlformat: opam:ocamlformat


### PR DESCRIPTION
Updated the ocamlformat because the old version fails to install for latest Ocaml, v5.3.0