### PR TITLE
Update Schema URL for TailwindCSS Language Server

### DIFF
--- a/packages/tailwindcss-language-server/package.yaml
+++ b/packages/tailwindcss-language-server/package.yaml
@@ -13,7 +13,7 @@ source:
   id: pkg:npm/%40tailwindcss/language-server@0.0.27
 
 schemas:
-  lsp: vscode:https://raw.githubusercontent.com/tailwindlabs/tailwindcss-intellisense/@tailwindcss/language-server@v{{version}}/packages/vscode-tailwindcss/package.json
+  lsp: https://raw.githubusercontent.com/tailwindlabs/tailwindcss-intellisense/v{{version}}/packages/vscode-tailwindcss/package.json
 
 bin:
   tailwindcss-language-server: npm:tailwindcss-language-server

--- a/packages/tailwindcss-language-server/package.yaml
+++ b/packages/tailwindcss-language-server/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:npm/%40tailwindcss/language-server@0.0.27
+  id: pkg:npm/%40tailwindcss/language-server@0.14.1
 
 schemas:
   lsp: https://raw.githubusercontent.com/tailwindlabs/tailwindcss-intellisense/v{{version}}/packages/vscode-tailwindcss/package.json


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->


The release tag for `tailwindcss-language-server` has changed from `@tailwindcss/language-server@vX.X.X` to `vX.X.X` starting from `v0.2.0`, which no longer aligns with the currently specified schema URL.

Ref: https://github.com/tailwindlabs/tailwindcss-intellisense/tags

Therefore, I have updated the schema URL to match the current release tag and update `tailwindcss-language-server` version to `v0.14.1`

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->

### Instalation

<img width="812" alt="スクリーンショット 2025-01-25 8 16 32" src="https://github.com/user-attachments/assets/b87c6193-95f9-48f8-a80a-b312bbb9fab7" />

### LspInfo

<img width="2515" alt="スクリーンショット 2025-01-25 8 24 52" src="https://github.com/user-attachments/assets/55b8f64a-6d65-4827-a0ff-f7d1f4478308" />

### Completion in CSS

<img width="1092" alt="スクリーンショット 2025-01-25 8 23 09" src="https://github.com/user-attachments/assets/7eb3409c-263b-4e65-a348-13fb4c2a49ec" />

### Completion in HTML

<img width="1874" alt="スクリーンショット 2025-01-25 8 28 18" src="https://github.com/user-attachments/assets/44f4d2b4-b020-4c0d-980b-4ab766a1e5e0" />


