### PR TITLE
feat(oxlint): add language server, bump to 0.15.8

### DIFF
--- a/packages/oxlint/package.yaml
+++ b/packages/oxlint/package.yaml
@@ -12,7 +12,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:npm/oxlint@0.15.8
+  id: pkg:npm/oxlint@0.15.10
 
 bin:
   oxlint: npm:oxlint

--- a/packages/oxlint/package.yaml
+++ b/packages/oxlint/package.yaml
@@ -1,30 +1,19 @@
 ---
 name: oxlint
 description: High-performance linter for JavaScript and TypeScript written in Rust.
-homepage: https://github.com/web-infra-dev/oxc
+homepage: https://github.com/oxc-project/oxc
 licenses:
   - MIT
 languages:
   - JavaScript
   - TypeScript
 categories:
+  - LSP
   - Linter
 
 source:
-  id: pkg:github/web-infra-dev/oxc@oxlint_v0.5.3
-  asset:
-    - target: darwin_arm64
-      file: oxlint-darwin-arm64
-    - target: darwin_x64
-      file: oxlint-darwin-x64
-    - target: linux_arm64_gnu
-      file: oxlint-linux-arm64-gnu
-    - target: linux_x64_gnu
-      file: oxlint-linux-x64-gnu
-    - target: win_arm64
-      file: oxlint-win32-arm64.exe
-    - target: win_x64
-      file: oxlint-win32-x64.exe
+  id: pkg:npm/oxlint@0.15.8
 
 bin:
-  oxlint: "{{source.asset.file}}"
+  oxlint: npm:oxlint
+  oxc_language_server: npm:oxc_language_server

--- a/packages/oxlint/package.yaml
+++ b/packages/oxlint/package.yaml
@@ -14,6 +14,9 @@ categories:
 source:
   id: pkg:npm/oxlint@0.15.10
 
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/oxc-project/oxc/oxlint_v{{version}}/editors/vscode/package.json
+
 bin:
   oxlint: npm:oxlint
   oxc_language_server: npm:oxc_language_server


### PR DESCRIPTION
## Describe your changes
This merge request updates the `oxlint` package to use npm. (Sorry for not waiting for a response in the related issue, I had too much free time on my hands :joy:) It also adds the `oxlint_language_server` binary.

## Issue ticket number and link
Closes #8709 

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
![Installed](https://github.com/user-attachments/assets/7c3fcbac-b9fb-45d1-9295-c07ff677f1e7)
![lsp setup](https://github.com/user-attachments/assets/015d651d-5ac0-4e39-b128-27d2a5e48bef)
