### PR TITLE
feat: add pyproject-fmt

### DIFF
--- a/packages/pyproject-fmt/package.yaml
+++ b/packages/pyproject-fmt/package.yaml
@@ -1,0 +1,17 @@
+---
+name: pyproject-fmt
+description: Format your pyproject.toml file
+homepage: https://pypi.org/project/pyproject-fmt/
+licenses:
+  - MIT
+languages:
+  - Python
+  - TOML
+categories:
+  - Formatter
+
+source:
+  id: pkg:pypi/pyproject-fmt@2.5.1
+
+bin:
+  pyproject-fmt: pypi:pyproject-fmt


### PR DESCRIPTION
## Describe your changes
This adds the [`pyproject-fmt`](https://pypi.org/project/pyproject-fmt/) formatter as a package. I marked it down as both TOML and Python language since it does directly pertain to Python projects and should show up if people search for Python, but it also formats a specific type of TOML file so I marked that as well.

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
