### PR TITLE
chore(fennel-ls): Update package and remove CI skipping

### DIFF
--- a/packages/fennel-ls/package.yaml
+++ b/packages/fennel-ls/package.yaml
@@ -10,13 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:luarocks/fennel-ls@0.1.2-2
+  id: pkg:luarocks/fennel-ls@0.1.3-4
 
 bin:
   fennel-ls: luarocks:fennel-ls
-
-ci_skip:
-  # https://github.com/mason-org/mason-registry/pull/4648
-  - darwin_x64
-  - linux_x64
-  - linux_x64_gnu


### PR DESCRIPTION
This should close #5265

## Describe your changes

Updates `fennel-ls` and lets it run on CI again.

## Issue ticket number and link

#5265: https://github.com/mason-org/mason-registry/issues/5265

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
