### PR TITLE
feat(bash-debug-adapter): expose `bashdb` as a shared directory

### DIFF
--- a/packages/bash-debug-adapter/package.yaml
+++ b/packages/bash-debug-adapter/package.yaml
@@ -16,3 +16,6 @@ source:
 
 bin:
   bash-debug-adapter: node:extension/out/bashDebug.js
+
+share:
+  bashdb/: extension/bashdb_dir/


### PR DESCRIPTION
## Describe your changes

The `bashdb` directory is important for setting up the debugger with `nvim-dap` and should be exposed with the `share/` directory. This is part of the efforts to help with the migration to Mason v2

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
