### PR TITLE
feat(codelldb): expose the `lldb` library as a shared folder

### DIFF
--- a/packages/codelldb/package.yaml
+++ b/packages/codelldb/package.yaml
@@ -59,3 +59,6 @@ source:
 
 bin:
   codelldb: "{{source.asset.bin}}"
+
+opt:
+  lldb/: lldb/


### PR DESCRIPTION
## Describe your changes
The `lldb` folder with the binaries and the library files are important files for setting up the debugger and should be marked as stable files. This is part of the efforts for the migration to Mason v2

## Issue ticket number and link
<!-- Leave empty if not available -->

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
