### PR TITLE
feat: add air language server

### DIFF
--- a/packages/air/package.yaml
+++ b/packages/air/package.yaml
@@ -11,7 +11,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/posit-dev/air@0.4.0
+  id: pkg:github/posit-dev/air@0.4.1
   asset:
     - target: darwin_arm64
       file: air-aarch64-apple-darwin.tar.gz

--- a/packages/air/package.yaml
+++ b/packages/air/package.yaml
@@ -1,0 +1,37 @@
+---
+name: air
+description: R formatter and language server
+homepage: https://posit-dev.github.io/air/
+licenses:
+  - MIT
+languages:
+  - R
+categories:
+  - Formatter
+  - LSP
+
+source:
+  id: pkg:github/posit-dev/air@0.4.0
+  asset:
+    - target: darwin_arm64
+      file: air-aarch64-apple-darwin.tar.gz
+      bin: air-aarch64-apple-darwin/air
+    - target: darwin_x64
+      file: air-x86_64-apple-darwin.tar.gz
+      bin: air-x86_64-apple-darwin/air
+    - target: linux_arm64_gnu
+      file: air-aarch64-unknown-linux-gnu.tar.gz
+      bin: air-aarch64-unknown-linux-gnu/air
+    - target: linux_x64_gnu
+      file: air-x86_64-unknown-linux-gnu.tar.gz
+      bin: air-x86_64-unknown-linux-gnu/air
+    - target: win_x86
+      file: air-aarch64-pc-windows-msvc.zip
+      bin: air.exe
+    - target: win_x64
+      file: air-x86_64-pc-windows-msvc.zip
+      bin: air.exe
+
+bin:
+  air: "{{source.asset.bin}}"
+

--- a/packages/air/package.yaml
+++ b/packages/air/package.yaml
@@ -32,6 +32,10 @@ source:
       file: air-x86_64-pc-windows-msvc.zip
       bin: air.exe
 
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/posit-dev/air/{{version}}/editors/code/package.json
+
+
 bin:
   air: "{{source.asset.bin}}"
 


### PR DESCRIPTION
## Describe your changes
Adds the [Air](https://github.com/posit-dev/air) formatter/LSP for R.

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

NB, Air was [recently added](https://github.com/neovim/nvim-lspconfig/pull/3614) to nvim-lspconfig.

I've tested installation for all platforms, and confirmed that the installation works and can be set up and configured using nvim-lspconfig (using the branch from the linked pull request).

This doesn't yet work with mason-lspconfig; I'll open a separate PR there. 

For some reason I found that I needed to use `bin: air-aarch64-apple-darwin/air` rather than `bin: air`, which is the format which other packages seem to use. I wasn't able to get to the bottom of why this was necessary - grateful if anyone could shed some light on this.

Thank you! 