### PR TITLE
Add angularls v18 and fix typescript dependency for v19.

### DIFF
--- a/packages/angular-language-server/package.yaml
+++ b/packages/angular-language-server/package.yaml
@@ -14,9 +14,14 @@ categories:
 source:
   id: pkg:npm/%40angular/language-server@19.1.0
   extra_packages:
-    - typescript@5.4.5
+    - typescript@5.5.4
 
   version_overrides:
+    - constraint: semver:<=18.2.0
+      id: pkg:npm/%40angular/language-server@18.2.0
+      extra_packages:
+        - typescript@5.4.5
+
     - constraint: semver:<=17.3.2
       id: pkg:npm/%40angular/language-server@17.3.2
       extra_packages:


### PR DESCRIPTION
## Describe your changes
angularls has the wrong typescript dependency for v19 and there is no option for v18.

## Issue ticket number and link

## Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

## Screenshots
