### PR TITLE
feat: Add nomad

### DIFF
--- a/packages/nomad/package.yaml
+++ b/packages/nomad/package.yaml
@@ -1,0 +1,43 @@
+---
+name: nomad
+description: |
+  Nomad is an easy-to-use, flexible, and performant workload orchestrator that can deploy a mix of microservice,
+  batch, containerized, and non-containerized applications. Nomad is easy to operate and scale and has native Consul
+  and Vault integrations.
+homepage: https://www.nomadproject.io/
+licenses:
+  - BUSL-1.1
+languages:
+  - Nomad
+categories:
+  - Formatter
+  - Linter
+  - Runtime
+
+source:
+  # renovate:datasource=github-releases
+  id: pkg:generic/hashicorp/nomad@v1.9.7
+  download:
+    - target: darwin_x64
+      files:
+        nomad.zip: https://releases.hashicorp.com/nomad/{{ version | strip_prefix "v" }}/nomad_{{ version | strip_prefix "v" }}_darwin_amd64.zip
+      bin: nomad
+    - target: darwin_arm64
+      files:
+        nomad.zip: https://releases.hashicorp.com/nomad/{{ version | strip_prefix "v" }}/nomad_{{ version | strip_prefix "v" }}_darwin_arm64.zip
+      bin: nomad
+    - target: linux_x64
+      files:
+        nomad.zip: https://releases.hashicorp.com/nomad/{{ version | strip_prefix "v" }}/nomad_{{ version | strip_prefix "v" }}_linux_amd64.zip
+      bin: nomad
+    - target: linux_arm64
+      files:
+        nomad.zip: https://releases.hashicorp.com/nomad/{{ version | strip_prefix "v" }}/nomad_{{ version | strip_prefix "v" }}_linux_arm64.zip
+      bin: nomad
+    - target: win_x64
+      files:
+        nomad: https://releases.hashicorp.com/nomad/{{ version | strip_prefix "v" }}/nomad_{{ version | strip_prefix "v" }}_windows_amd64.zip
+      bin: nomad
+
+bin:
+  nomad: "{{source.download.bin}}"


### PR DESCRIPTION
## Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Added nomad, a Hashicorp tool that comes with built-in `fmt` commands for files of their type. 

## Issue ticket number and link
<!-- Leave empty if not available -->
Split from: https://github.com/mason-org/mason-registry/pull/8383

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
<!-- Leave empty if not applicable -->
<img width="766" alt="image" src="https://github.com/user-attachments/assets/856136ed-ef7b-47b0-b385-3131ca172216" />

<img width="434" alt="image" src="https://github.com/user-attachments/assets/843a99a5-e90e-4f29-a768-744bd983f904" />


