### PR TITLE
feat/fish_lsp: added fish-lsp server

### DIFF
--- a/packages/fish-lsp/package.yaml
+++ b/packages/fish-lsp/package.yaml
@@ -1,0 +1,16 @@
+---
+name: fish-lsp
+description: Language Server for fish shell scripts.
+homepage: https://github.com/ndonfris/fish-lsp/
+licenses:
+  - MIT
+languages:
+  - Fish
+categories:
+  - LSP
+
+source:
+  id: pkg:npm/fish-lsp@1.0.8-4
+
+bin:
+  fish-lsp: npm:fish-lsp


### PR DESCRIPTION
## Describe your changes
Added fish-lsp server for `*.fish` files since there are no any servers for fish language.

## Issue ticket number and link
[#1734](https://github.com/williamboman/mason.nvim/issues/1734)

## For new packages: Evidence on requirement fulfillment (new packages only)
1. [more than 100 stars](https://github.com/ndonfris/fish-lsp)
2. [supported by nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/ff6471d4f837354d8257dfa326b031dd8858b16e/doc/configs.md?plain=1#L107)

## Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

## Screenshots
![CleanShot 2025-04-02 at 01 13 40@2x](https://github.com/user-attachments/assets/e3cc9255-13d1-4df5-9ad6-bd3ffaa737bb)
![image](https://github.com/user-attachments/assets/1f50dab1-d53c-4d34-a24e-6bc287dbc055)

