### PR TITLE
fix: fix capitalization of `BitBake` filetype

### DIFF
--- a/packages/language-server-bitbake/package.yaml
+++ b/packages/language-server-bitbake/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/yoctoproject/vscode-bitbake
 licenses:
   - MIT
 languages:
-  - Bitbake
+  - BitBake
 categories:
   - LSP
 

--- a/packages/oelint-adv/package.yaml
+++ b/packages/oelint-adv/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/priv-kweihmann/oelint-adv
 licenses:
   - BSD-2-Clause
 languages:
-  - Bitbake
+  - BitBake
 categories:
   - Linter
 


### PR DESCRIPTION
### Describe your changes
The casing of `BitBake` is incorrect and should be resolved.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
