### PR TITLE
fix(codelldb): fix incorrect `lldb` path

### DIFF
--- a/packages/codelldb/package.yaml
+++ b/packages/codelldb/package.yaml
@@ -61,4 +61,4 @@ bin:
   codelldb: "{{source.asset.bin}}"
 
 opt:
-  lldb/: lldb/
+  lldb/: extension/lldb/


### PR DESCRIPTION
### Describe your changes
The path to the `lldb` library is incorrect. This resolves it

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
