### PR TITLE
ci: add stale-bot

### DIFF
--- a/.github/workflows/stale-bot.yml
+++ b/.github/workflows/stale-bot.yml
@@ -1,0 +1,35 @@
+name: Stale bot
+on:
+  schedule:
+    - cron: "18 04 * * 3"
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Close stale issues/PRs
+        uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # DOCS https://github.com/actions/stale#all-options
+          days-before-stale: 90
+          days-before-close: 7
+
+          stale-issue-label: Stale
+          stale-issue-message: |
+            This issue has been automatically marked as stale.
+            If this issue is still relevant, please leave any comment, and it will be kept open.
+          close-issue-message: |
+            This issue has been closed due to inactivity, and will not be monitored.
+
+          stale-PR-label: Stale
+          stale-pr-message: |
+            This PR has been automatically marked as stale. 
+            If this issue is still relevant, please leave any comment, and it will be kept open.
+          close-pr-message: |
+            This PR has been closed due to inactivity, and will not be monitored.


### PR DESCRIPTION
### Problem
We have a bunch of PRs and issues that are really old and appear to be outdated, or do not have a reaction by the PR creator after requesting changes. 

### Solution
The stale-bot could be a useful tool to reduce maintenance workload by automatically closing such issues/PRs.

I set the parameters to be very generous, an issue/PR is only considered stale after 3 months: If the creator of a PR does not implement the requested changes after such a long time, I think it is safe to assume that the creator has lost interest and abandoned the PR. (And in case that assumption is wrong, it is not a big effort for the creator to simply open a new PR.)