### PR TITLE
fix: typo in api-linter definition

### DIFF
--- a/packages/api-linter/package.yaml
+++ b/packages/api-linter/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/googleapis/api-linter
 licenses:
   - Apache-2.0
 languages:
-  - ProtoBuf
+  - Protobuf
 categories:
   - Linter
 


### PR DESCRIPTION
fix: typo in api-linter definition
#9653 
