### PR TITLE
chore(ruff-lsp): add deprecation message

### DIFF
--- a/packages/ruff-lsp/package.yaml
+++ b/packages/ruff-lsp/package.yaml
@@ -9,6 +9,10 @@ languages:
 categories:
   - LSP
 
+deprecation:
+  since: v0.0.61
+  message: `ruff server` supports the same feature set as ruff-lsp, but with superior performance and no installation required. ruff server was marked as stable in Ruff v0.5.3.
+
 source:
   id: pkg:pypi/ruff-lsp@0.0.62
 

--- a/packages/ruff-lsp/package.yaml
+++ b/packages/ruff-lsp/package.yaml
@@ -11,7 +11,7 @@ categories:
 
 deprecation:
   since: v0.0.61
-  message: `ruff server` supports the same feature set as ruff-lsp, but with superior performance and no installation required. ruff server was marked as stable in Ruff v0.5.3.
+  message: please use the mason package `ruff` as replacement. The command `ruff server` supports the same feature set as ruff-lsp, but with superior performance and no installation required. ruff server was marked as stable in Ruff v0.5.3.
 
 source:
   id: pkg:pypi/ruff-lsp@0.0.62


### PR DESCRIPTION
### Describe your changes

Added deprecation message to `ruff-lsp` package.yaml.

Followed example from [xo](https://github.com/mason-org/mason-registry/blob/main/packages/xo/package.yaml), but noticed at the same time [CONTRIBUTING.md](https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#package-specification) package specs doesn't include the `deprecation` keyword.

### Issue ticket number and link

- https://github.com/mason-org/mason-registry/issues/9707
- https://github.com/astral-sh/ruff-lsp/pull/520

### Checklist before requesting a review

Removed because not applicable.

### Screenshots

<!-- Leave empty if not applicable -->
