### PR TITLE
chore: fix nginx language capitalization

### DIFF
--- a/packages/nginx-language-server/package.yaml
+++ b/packages/nginx-language-server/package.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/pappasam/nginx-language-server
 licenses:
   - GPL-3.0-or-later
 languages:
-  - Nginx
+  - nginx
 categories:
   - LSP
 


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Fixes language capitalization to match the suggested stylization (nginx or NGINX).

The CI test suite should've already validated conformance of this (not the stylization but that languages are
capitalized the same across the registry to avoid duplicates). Fixed in
https://github.com/mason-org/actions/commit/4887821e475c60c9c60fd02f0e1a1435b007602a.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots

<img width="508" alt="Screenshot 2025-04-17 at 12 52 55" src="https://github.com/user-attachments/assets/795cb605-afea-4acd-aa39-207119957037" />
