### PR TITLE
feat(cairo): remove lsp schema (repo doesn't exist)

### DIFF
--- a/packages/cairo-language-server/package.yaml
+++ b/packages/cairo-language-server/package.yaml
@@ -12,8 +12,5 @@ categories:
 source:
   id: pkg:cargo/cairo-language-server@2.11.2
 
-schemas:
-  lsp: vscode:https://raw.githubusercontent.com/starkware-libs/cairo/v{{version}}/vscode-cairo/package.json
-
 bin:
   cairo-language-server: cargo:cairo-language-server


### PR DESCRIPTION
### Describe your changes
Removes the vscode lsp schema as the vscode folder doesn't exist anymore. Blocks a lot of CIs

### Issue ticket number and link
<!-- Leave empty if not available -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
