### PR TITLE
feat: use OmniSharp/OmniSharp.exe binary provided in the package

### DIFF
--- a/packages/omnisharp/package.yaml
+++ b/packages/omnisharp/package.yaml
@@ -38,7 +38,6 @@ schemas:
 
 bin:
   OmniSharp: "{{source.asset.bin}}"
-  omnisharp: dotnet:libexec/OmniSharp.dll
 
 neovim:
   lspconfig: omnisharp

--- a/packages/omnisharp/package.yaml
+++ b/packages/omnisharp/package.yaml
@@ -15,20 +15,26 @@ source:
   id: pkg:github/OmniSharp/omnisharp-roslyn@v1.39.13
   asset:
     - target: darwin_x64
-      file: omnisharp-osx-x64-net6.0.zip:libexec/
+      file: omnisharp-osx-x64-net6.0.zip
+      bin: OmniSharp
     - target: darwin_arm64
-      file: omnisharp-osx-arm64-net6.0.zip:libexec/
+      file: omnisharp-osx-arm64-net6.0.zip
+      bin: OmniSharp
     - target: linux_x64
-      file: omnisharp-linux-x64-net6.0.zip:libexec/
+      file: omnisharp-linux-x64-net6.0.zip
+      bin: OmniSharp
     - target: linux_arm64
-      file: omnisharp-linux-arm64-net6.0.zip:libexec/
+      file: omnisharp-linux-arm64-net6.0.zip
+      bin: OmniSharp
     - target: win_x64
-      file: omnisharp-win-x64-net6.0.zip:libexec/
+      file: omnisharp-win-x64-net6.0.zip
+      bin: OmniSharp.exe
     - target: win_arm64
-      file: omnisharp-win-arm64-net6.0.zip:libexec/
+      file: omnisharp-win-arm64-net6.0.zip
+      bin: OmniSharp.exe
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/OmniSharp/omnisharp-vscode/master/package.json
 
 bin:
-  omnisharp: dotnet:libexec/OmniSharp.dll
+  OmniSharp: "{{source.asset.bin}}"


### PR DESCRIPTION
### Describe your changes
With the new way how Language Server Config can be provided in neovim, we changed the default binary to match the ones provided inside the package:

See official repo docs how binaries are named in the official package (`OmniSharp` and`OmniSharp.exe`):
https://github.com/OmniSharp/omnisharp-roslyn?tab=readme-ov-file#building

See new LSP config for OmniSharp:
https://github.com/neovim/nvim-lspconfig/blob/master/lsp/omnisharp.lua#L19

The benefit in doing so, would be that the LSP config does not have to change if the binary is in users PATH, and could be picked up, resulting in hopefully 'just work experience', regardless if the user installed the server manually or with Mason. 

### Checklist before requesting a review
- [x] I have successfully tested installation of the package (but only on Linux).
- [x] I have successfully tested the package after installation (but only on Linux).
- [x] I have successfully tested installation of the package (for Windows, maybe someone could test it please).
- [x] I have successfully tested the package after installation (for Windows, maybe someone could test it please).

For MacOS I expect it to work as it works for Linux.
