### PR TITLE
fix(zk): update darwin_arm64 asset file

### DIFF
--- a/packages/zk/package.yaml
+++ b/packages/zk/package.yaml
@@ -19,7 +19,7 @@ source:
     - target: linux_x86
       file: zk-{{version}}-linux-i386.tar.gz
     - target: darwin_arm64
-      file: zk-{{version}}-macos-arm64.tar.gz
+      file: zk-{{version}}-macos_arm64.tar.gz
     - target: darwin_x64
       file: zk-{{version}}-macos-x86_64.tar.gz
 
@@ -28,5 +28,4 @@ bin:
 
 # gzip behaves weirdly on macOS
 ci_skip:
-  - darwin_arm64
   - darwin_x64


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Fixes the asset file for `darwin_arm64`. I also removed `ci_skip` to see if the runners are able to unpack this. The
gzip bug seemed a bit weird, maybe it's Intel mac related (I don't have an Intel mac anymore so can't test it myself).

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
