### PR TITLE
ci: skip package tests if PR has `ci:skip-package-tests` label

### DIFF
--- a/.github/workflows/package-tests.yaml
+++ b/.github/workflows/package-tests.yaml
@@ -28,3 +28,4 @@ jobs:
     uses: mason-org/actions/.github/workflows/package-tests.yaml@v1
     with:
       packages: ${{ github.event.inputs.packages }}
+      skip: ${{ github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'ci:skip-package-tests') }}


### PR DESCRIPTION
### Describe your changes
Allows skipping the entire package tests job if this label is present. Useful/needed for sweeping registry changes such as #9774.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
