### PR TITLE
feat(just-lsp): add additional targets

### DIFF
--- a/packages/just-lsp/package.yaml
+++ b/packages/just-lsp/package.yaml
@@ -27,9 +27,6 @@ source:
     - target: linux_arm_gnu
       file: just-lsp-{{version}}-arm-unknown-linux-gnueabihf.tar.gz
       bin: just-lsp
-    - target: linux_arm_musl
-      file: just-lsp-{{version}}-arm-unknown-linux-musleabihf.tar.gz
-      bin: just-lsp
     - target: linux_armv7_gnu
       file: just-lsp-{{version}}-armv7-unknown-linux-gnueabihf.tar.gz
       bin: just-lsp

--- a/packages/just-lsp/package.yaml
+++ b/packages/just-lsp/package.yaml
@@ -18,8 +18,20 @@ source:
     - target: win_arm64
       file: just-lsp-{{version}}-aarch64-pc-windows-msvc.zip
       bin: just-lsp.exe
+    - target: linux_arm64_gnu
+      file: just-lsp-{{version}}-aarch64-unknown-linux-gnu.tar.gz
+      bin: just-lsp
     - target: linux_arm64_musl
       file: just-lsp-{{version}}-aarch64-unknown-linux-musl.tar.gz
+      bin: just-lsp
+    - target: linux_arm_gnu
+      file: just-lsp-{{version}}-arm-unknown-linux-gnueabihf.tar.gz
+      bin: just-lsp
+    - target: linux_arm_musl
+      file: just-lsp-{{version}}-arm-unknown-linux-musleabihf.tar.gz
+      bin: just-lsp
+    - target: linux_armv7_gnu
+      file: just-lsp-{{version}}-armv7-unknown-linux-gnueabihf.tar.gz
       bin: just-lsp
     - target: linux_arm
       file: just-lsp-{{version}}-armv7-unknown-linux-musleabihf.tar.gz

--- a/packages/just-lsp/package.yaml
+++ b/packages/just-lsp/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/terror/just-lsp@0.2.0
+  id: pkg:github/terror/just-lsp@0.2.1
   asset:
     - target: darwin_arm64
       file: just-lsp-{{version}}-aarch64-apple-darwin.tar.gz

--- a/packages/just-lsp/package.yaml
+++ b/packages/just-lsp/package.yaml
@@ -33,6 +33,9 @@ source:
     - target: linux_x64_musl
       file: just-lsp-{{version}}-x86_64-unknown-linux-musl.tar.gz
       bin: just-lsp
+    - target: linux_x64_gnu
+      file: just-lsp-{{version}}-x86_64-unknown-linux-gnu.tar.gz
+      bin: just-lsp
 
 bin:
   just-lsp: "{{source.asset.bin}}"


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

This PR simply adds linux arm and gnu targets for the `just-lsp` lsp server. Pretty much whatever was missing from the [supported packages](https://github.com/terror/just-lsp/releases/tag/0.2.1).

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->
