### PR TITLE
bump(haskell-language-server): Update to version 2.10.0.0

### DIFF
--- a/packages/haskell-language-server/package.yaml
+++ b/packages/haskell-language-server/package.yaml
@@ -11,7 +11,7 @@ categories:
 
 source:
   # renovate:datasource=github-releases
-  id: pkg:generic/haskell/haskell-language-server@2.9.0.1
+  id: pkg:generic/haskell/haskell-language-server@2.10.0.0
   build:
     - target: unix
       run: ghcup install hls "$VERSION" -i "$PWD"
@@ -20,11 +20,11 @@ source:
         VERSION: "{{version}}"
       bin:
         wrapper: bin/haskell-language-server-wrapper
-        server_9_2_8: bin/haskell-language-server-9.2.8
         server_9_4_8: bin/haskell-language-server-9.4.8
-        server_9_6_6: bin/haskell-language-server-9.6.6
-        server_9_8_2: bin/haskell-language-server-9.8.2
+        server_9_6_7: bin/haskell-language-server-9.6.7
+        server_9_8_4: bin/haskell-language-server-9.8.4
         server_9_10_1: bin/haskell-language-server-9.10.1
+        server_9_12_2: bin/haskell-language-server-9.12.2
 
     - target: win
       run: ghcup install hls $env:VERSION -i ($pwd).path
@@ -33,17 +33,17 @@ source:
         VERSION: "{{version}}"
       bin:
         wrapper: haskell-language-server-wrapper.exe
-        server_9_2_8: haskell-language-server-9.2.8.exe
         server_9_4_8: haskell-language-server-9.4.8.exe
-        server_9_6_6: haskell-language-server-9.6.6.exe
-        server_9_8_2: haskell-language-server-9.8.2.exe
+        server_9_6_7: haskell-language-server-9.6.7.exe
+        server_9_8_4: haskell-language-server-9.8.4.exe
         server_9_10_1: haskell-language-server-9.10.1.exe
+        server_9_12_2: haskell-language-server-9.12.2.exe
 
 bin:
   haskell-language-server-wrapper: "{{source.build.bin.wrapper}}"
   # https://github.com/haskell/haskell-language-server/issues/3162
-  haskell-language-server-9.2.8: "{{source.build.bin.server_9_2_8}}"
   haskell-language-server-9.4.8: "{{source.build.bin.server_9_4_8}}"
-  haskell-language-server-9.6.6: "{{source.build.bin.server_9_6_6}}"
-  haskell-language-server-9.8.2: "{{source.build.bin.server_9_8_2}}"
+  haskell-language-server-9.6.7: "{{source.build.bin.server_9_6_7}}"
+  haskell-language-server-9.8.4: "{{source.build.bin.server_9_8_4}}"
   haskell-language-server-9.10.1: "{{source.build.bin.server_9_10_1}}"
+  haskell-language-server-9.12.2: "{{source.build.bin.server_9_12_2}}"


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Update Haskell Language Server to version 2.10.0.0 and the supported binary versions specified [here](https://github.com/haskell/haskell-language-server/releases/tag/2.10.0.0)

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->