### PR TITLE
feat: add missing nvim-lspconfig specs to some LSPs

### DIFF
--- a/packages/emmylua_ls/package.yaml
+++ b/packages/emmylua_ls/package.yaml
@@ -42,3 +42,6 @@ source:
 
 bin:
   emmylua_ls: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: emmylua_ls

--- a/packages/just-lsp/package.yaml
+++ b/packages/just-lsp/package.yaml
@@ -48,3 +48,6 @@ source:
 
 bin:
   just-lsp: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: just

--- a/packages/ltex-ls-plus/package.yaml
+++ b/packages/ltex-ls-plus/package.yaml
@@ -61,3 +61,6 @@ schemas:
 bin:
   ltex-ls-plus: "{{source.asset.bin.lsp}}"
   ltex-cli-plus: "{{source.asset.bin.cli}}"
+
+neovim:
+  lspconfig: ltex_plus

--- a/packages/ts_query_ls/package.yaml
+++ b/packages/ts_query_ls/package.yaml
@@ -30,3 +30,6 @@ source:
 
 bin:
   ts_query_ls: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: ts_query_ls


### PR DESCRIPTION
### Describe your changes
follow-up to #9774, add missing `neovim.lspconfig` to some LSPs. 