### PR TITLE
feat(protols): specify neovim.lspconfig mapping

### DIFF
--- a/packages/protols/package.yaml
+++ b/packages/protols/package.yaml
@@ -14,3 +14,6 @@ source:
 
 bin:
   protols: cargo:protols
+
+neovim:
+  lspconfig: protols


### PR DESCRIPTION



### Describe your changes

Set `neovim.lspconfig` mapping for `protols`

`protols` is a valid server in nvim-lspconfig (see https://github.com/neovim/nvim-lspconfig/blob/master/lsp/protols.lua) and it should have the `neovim.lspconfig` property set.

### Issue ticket number and link

I mentioned this in https://github.com/mason-org/mason-registry/pull/9774#issuecomment-2857982842

### Evidence on requirement fulfillment (new packages only)


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots

Installing protols automatically

<img width="748" alt="image" src="https://github.com/user-attachments/assets/717416ed-4126-4090-8847-eaab89dc5b3f" />

protols successfully installed

<img width="709" alt="image" src="https://github.com/user-attachments/assets/d231ddd6-baf3-46b0-99e8-b99942017a7d" />

Diagnostics

<img width="751" alt="image" src="https://github.com/user-attachments/assets/d5ad6b2d-9dc6-458e-9375-d86d24819cb0" />


