### PR TITLE
feat: add kdlfmt package (KDL formatter, Rust/cargo-based)

### DIFF
--- a/packages/kdlfmt/package.yaml
+++ b/packages/kdlfmt/package.yaml
@@ -15,7 +15,7 @@ source:
       bin: kdlfmt-aarch64-apple-darwin/kdlfmt
     - target: darwin_x64
       file: kdlfmt-x86_64-apple-darwin.tar.xz
-      bin: kdlfmt-aarch64-apple-darwin/kdlfmt
+      bin: kdlfmt-x86_64-apple-darwin/kdlfmt
     - target: linux_arm64_gnu
       file: kdlfmt-aarch64-unknown-linux-gnu.tar.xz
       bin: kdlfmt-aarch64-unknown-linux-gnu/kdlfmt

--- a/packages/kdlfmt/package.yaml
+++ b/packages/kdlfmt/package.yaml
@@ -1,0 +1,17 @@
+---
+name: kdlfmt
+description: A code formatter for KDL documents.
+homepage: https://github.com/hougesen/kdlfmt
+licenses:
+  - MIT
+languages:
+  - KDL
+  - Rust
+categories:
+  - Formatter
+
+source:
+  id: pkg:cargo/kdlfmt@0.0.16
+
+bin:
+  kdlfmt: cargo:kdlfmt

--- a/packages/kdlfmt/package.yaml
+++ b/packages/kdlfmt/package.yaml
@@ -1,4 +1,3 @@
----
 name: kdlfmt
 description: A code formatter for KDL documents.
 homepage: https://github.com/hougesen/kdlfmt
@@ -6,12 +5,28 @@ licenses:
   - MIT
 languages:
   - KDL
-  - Rust
 categories:
   - Formatter
-
 source:
-  id: pkg:cargo/kdlfmt@0.0.16
-
+  id: pkg:github/hougesen/kdlfmt@0.1.2
+  asset:
+    - target: darwin_arm64
+      file: kdlfmt-aarch64-apple-darwin.tar.xz
+      bin: kdlfmt-aarch64-apple-darwin/kdlfmt
+    - target: darwin_x64
+      file: kdlfmt-x86_64-apple-darwin.tar.xz
+      bin: kdlfmt-aarch64-apple-darwin/kdlfmt
+    - target: linux_arm64_gnu
+      file: kdlfmt-aarch64-unknown-linux-gnu.tar.xz
+      bin: kdlfmt-aarch64-unknown-linux-gnu/kdlfmt
+    - target: linux_x64_gnu
+      file: kdlfmt-x86_64-unknown-linux-gnu.tar.xz
+      bin: kdlfmt-x86_64-unknown-linux-gnu/kdlfmt
+    - target: win_x86
+      file: kdlfmt-x86_64-pc-windows-msvc.zip
+      bin: kdlfmt.exe
+    - target: win_x64
+      file: kdlfmt-x86_64-pc-windows-msvc.zip
+      bin: kdlfmt.exe
 bin:
-  kdlfmt: cargo:kdlfmt
+  kdlfmt: "{{source.asset.bin}}"

--- a/packages/kdlfmt/package.yaml
+++ b/packages/kdlfmt/package.yaml
@@ -8,7 +8,7 @@ languages:
 categories:
   - Formatter
 source:
-  id: pkg:github/hougesen/kdlfmt@0.1.2
+  id: pkg:github/hougesen/kdlfmt@v0.1.2
   asset:
     - target: darwin_arm64
       file: kdlfmt-aarch64-apple-darwin.tar.xz


### PR DESCRIPTION
### Describe your changes

Added a new package definition for `kdlfmt`, a Rust-based code formatter for KDL documents. The package uses the latest release from crates.io and exposes the `kdlfmt` binary via Mason. This enables users to easily install and use `kdlfmt` for formatting `.kdl` files through Mason.

### Evidence on requirement fulfillment (new packages only)
- [kdlfmt on crates.io](https://crates.io/crates/kdlfmt)
- [kdlfmt GitHub repository](https://github.com/hougesen/kdlfmt)
- [Formatter requirements in CONTRIBUTING.md](https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements)
- Successfully tested installation and formatting of `.kdl` files locally.

### Checklist before requesting a review
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.  
      (Not applicable)
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
