### PR TITLE
feat: Add ty

### DIFF
--- a/packages/ty/package.yaml
+++ b/packages/ty/package.yaml
@@ -1,0 +1,20 @@
+---
+name: ty
+description: An extremely fast Python type checker and language server, written in Rust.
+homepage: https://github.com/astral-sh/ty
+licenses:
+  - MIT
+languages:
+  - Python
+categories:
+  - Linter
+  - LSP
+
+source:
+  id: pkg:pypi/ty@0.0.0a8
+
+bin:
+  ty: pypi:ty
+
+neovim:
+  lspconfig: ty


### PR DESCRIPTION
### Describe your changes
Adds [ty](https://github.com/astral-sh/ty), a type checker linter/LSP for Python by [Astral](https://astral.sh).

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->
1. [5.9k stars on GitHub](https://github.com/astral-sh/ty)
2. [600+ VS Code extension installs in a few days](https://marketplace.visualstudio.com/items?itemName=astral-sh.ty&ssr=false#overview)
3. Pending on https://github.com/neovim/nvim-lspconfig/pull/3842
4. Arguable whether it meets this requirement. Astral is reputable, having built [uv](https://docs.astral.sh/uv) — which is becoming quite popular — and [ruff](https://docs.astral.sh/ruff), though ty is still in alpha and is not production-ready.


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<figure>
<img width="1170" alt="Screenshot of diagnostics produced by ty's LSP" src="https://github.com/user-attachments/assets/cc3ea18c-b5c0-43f1-ab78-5b2cad7b2821" />
<figcaption>Screenshot of diagnostics produced by ty's LSP</figcaption>
</figure>

