### PR TITLE
Add missing angular-language-server v19 stanza and fix typescript dep for v20

### DIFF
--- a/packages/angular-language-server/package.yaml
+++ b/packages/angular-language-server/package.yaml
@@ -14,9 +14,14 @@ categories:
 source:
   id: pkg:npm/%40angular/language-server@20.0.0
   extra_packages:
-    - typescript@5.5.4
+    - typescript@5.8.3
 
   version_overrides:
+    - constraint: semver:<=19.2.4
+      id: pkg:npm/%40angular/language-server@19.2.4
+      extra_packages:
+        - typescript@5.8.3
+
     - constraint: semver:<=18.2.0
       id: pkg:npm/%40angular/language-server@18.2.0
       extra_packages:


### PR DESCRIPTION
### Describe your changes
Add missing angular-language-server v19 stanza and fix typescript dep for v20

### Issue ticket number and link

### Evidence on requirement fulfillment (new packages only)

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
