### PR TITLE
fix: remove darwin_arm64 from hadolint x86_64

### DIFF
--- a/packages/hadolint/package.yaml
+++ b/packages/hadolint/package.yaml
@@ -12,7 +12,7 @@ categories:
 source:
   id: pkg:github/hadolint/hadolint@v2.12.0
   asset:
-    - target: [darwin_x64, darwin_arm64]
+    - target: darwin_x64
       file: hadolint-Darwin-x86_64
     - target: linux_x64
       file: hadolint-Linux-x86_64


### PR DESCRIPTION
### Describe your changes

Hadolint x86_64 on Apple Silicon causes "bad CPU type" error message.

### Issue ticket number and link

Closes #10074

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
