### PR TITLE
feat: add Pyrefly

### DIFF
--- a/packages/pyrefly/package.yaml
+++ b/packages/pyrefly/package.yaml
@@ -1,0 +1,23 @@
+---
+name: pyrefly
+description: Pyrefly, a faster Python type checker written in Rust
+homepage: https://pyrefly.org/
+licenses:
+  - MIT
+languages:
+  - Python
+categories:
+  - Linter
+  - LSP
+
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/facebook/pyrefly/{{version}}/lsp/package.json
+
+source:
+  id: pkg:pypi/pyrefly@0.16.1
+
+bin:
+  pyrefly: pypi:pyrefly
+
+neovim:
+  lspconfig: pyrefly


### PR DESCRIPTION
I'm part of the Pyrefly team at Meta, and we're working on a new language server/type checker (called Pyrefly 😄, [website](https://pyrefly.org/), [github](https://github.com/facebook/pyrefly)) to replace our other Python language server, Pyre. Pyre isn't fully ready to be deprecated yet, but we just made our big announcement at PyCon this year, and are excited for users to test it out.

I'd love to add it to Mason when possible, since it would make it super easy to install/use!

### Describe your changes
This PR adds the `packages/pyrefly/package.yaml` file, which enables Pyrefly in the Mason UI and enables users to install.

### Evidence on requirement fulfillment (new packages only)
- [>1k stars](https://github.com/facebook/pyrefly)
- Relevant user bases: [VSCode](https://marketplace.visualstudio.com/items?itemName=meta.pyrefly), [OpenVSX](https://open-vsx.org/extension/meta/pyrefly)
- [Approved at `nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/pull/3856)

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->