### PR TITLE
feat(pinact): add pinact cli

### DIFF
--- a/packages/pinact/package.yaml
+++ b/packages/pinact/package.yaml
@@ -1,0 +1,35 @@
+---
+name: pinact
+description: Update & pin GitHub Workflows and Actions to commit SHAs
+homepage: https://github.com/suzuki-shunsuke/pinact
+licenses:
+  - MIT
+languages:
+  - YAML
+categories:
+  - Formatter
+
+source:
+  id: pkg:github/suzuki-shunsuke/pinact@v3.1.2
+  asset:
+    - target: darwin_x64
+      file: pinact_darwin_amd64.tar.gz
+      bin: actionlint
+    - target: darwin_arm64
+      file: pinact_darwin_arm64.tar.gz
+      bin: actionlint
+    - target: linux_x64
+      file: pinact_linux_amd64.tar.gz
+      bin: actionlint
+    - target: linux_arm64
+      file: pinact_linux_arm64.tar.gz
+      bin: actionlint
+    - target: win_x64
+      file: pinact_windows_amd64.zip
+      bin: actionlint.exe
+    - target: win_arm64
+      file: pinact_windows_arm64.zip
+      bin: actionlint.exe
+
+bin:
+  pinact: "{{source.asset.bin}}"


### PR DESCRIPTION
### Describe your changes

Add [pinact](https://github.com/suzuki-shunsuke/pinact), a utility that pins GitHub Actions & Workflows to commit SHAs instead of Git Tags to defend against software supply attacks (e.g. [tj-actions/changed-files](https://www.cisa.gov/news-events/alerts/2025/03/18/supply-chain-compromise-third-party-tj-actionschanged-files-cve-2025-30066-and-reviewdogaction))

### Issue ticket number and link


### Evidence on requirement fulfillment (new packages only)

- Project has 300+ stars on GH
- Project is actively maintained (latest commit is <24h ago)

### Checklist before requesting a review

- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots

