### PR TITLE
fix(vue-language-server): nvim-lspconfig renamed to `vue_ls`

### DIFF
--- a/packages/vue-language-server/package.yaml
+++ b/packages/vue-language-server/package.yaml
@@ -21,4 +21,4 @@ bin:
   vue-language-server: npm:vue-language-server
 
 neovim:
-  lspconfig: volar
+  lspconfig: vue_ls


### PR DESCRIPTION
### Describe your changes
This follows up a recent pull request on `nvim-lspconfig` that renames `volar` to `vue_ls`: https://github.com/neovim/nvim-lspconfig/pull/3843

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
