### PR TITLE
revert(omnisharp): partially revert config to fix #10084

### DIFF
--- a/packages/omnisharp/package.yaml
+++ b/packages/omnisharp/package.yaml
@@ -15,29 +15,23 @@ source:
   id: pkg:github/OmniSharp/omnisharp-roslyn@v1.39.13
   asset:
     - target: darwin_x64
-      file: omnisharp-osx-x64-net6.0.zip
-      bin: OmniSharp
+      file: omnisharp-osx-x64-net6.0.zip:libexec/
     - target: darwin_arm64
-      file: omnisharp-osx-arm64-net6.0.zip
-      bin: OmniSharp
+      file: omnisharp-osx-arm64-net6.0.zip:libexec/
     - target: linux_x64
-      file: omnisharp-linux-x64-net6.0.zip
-      bin: OmniSharp
+      file: omnisharp-linux-x64-net6.0.zip:libexec/
     - target: linux_arm64
-      file: omnisharp-linux-arm64-net6.0.zip
-      bin: OmniSharp
+      file: omnisharp-linux-arm64-net6.0.zip:libexec/
     - target: win_x64
-      file: omnisharp-win-x64-net6.0.zip
-      bin: OmniSharp.exe
+      file: omnisharp-win-x64-net6.0.zip:libexec/
     - target: win_arm64
-      file: omnisharp-win-arm64-net6.0.zip
-      bin: OmniSharp.exe
+      file: omnisharp-win-arm64-net6.0.zip:libexec/
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/OmniSharp/omnisharp-vscode/master/package.json
 
 bin:
-  OmniSharp: "{{source.asset.bin}}"
+  OmniSharp: dotnet:libexec/OmniSharp.dll
 
 neovim:
   lspconfig: omnisharp


### PR DESCRIPTION
### Describe your changes
reverted back partially the changes made by me in https://github.com/mason-org/mason-registry/pull/9738 as they cause issues on macos arm64 arch.

It seems to be a better approach to use the `.dll`.

The change that stays is the renaming from `omnisharp` to `OmniSharp`.

### Issue ticket number and link
fixes: https://github.com/mason-org/mason-registry/issues/10084

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] (linux) I have successfully tested installation of the package.
- [x] (linux) I have successfully tested the package after installation.
- [ ] (windows) I have successfully tested installation of the package.
- [ ] (windows) I have successfully tested the package after installation.
- [x] (macos) I have successfully tested installation of the package.
- [x] (macos) I have successfully tested the package after installation.

PS: sorry for the trouble :(