### PR TITLE
feat: add tofu-ls

### DIFF
--- a/packages/tofu-ls/package.yaml
+++ b/packages/tofu-ls/package.yaml
@@ -1,0 +1,43 @@
+---
+name: tofu-ls
+description: OpenTofu Language Server
+homepage: https://github.com/opentofu/tofu-ls
+licenses:
+  - MPL-2.0
+languages:
+  - OpenTofu
+categories:
+  - LSP
+neovim:
+  lspconfig: tofu_ls
+
+source:
+  id: pkg:github/opentofu/tofu-ls@v0.0.1-alpha5
+  asset:
+    - target: darwin_arm64
+      file: tofu-ls_Darwin_arm64.tar.gz
+      bin: tofu-ls
+    - target: darwin_x64
+      file: tofu-ls_Darwin_x86_64.tar.gz
+      bin: tofu-ls
+    - target: linux_arm64
+      file: tofu-ls_Linux_arm64.tar.gz
+      bin: tofu-ls
+    - target: linux_x86
+      file: tofu-ls_Linux_i386.tar.gz
+      bin: tofu-ls
+    - target: linux_x64
+      file: tofu-ls_Linux_x86_64.tar.gz
+      bin: tofu-ls
+    - target: win_arm64
+      file: tofu-ls_Windows_arm64.tar.gz
+      bin: tofu-ls.exe
+    - target: win_x86
+      file: tofu-ls_Windows_i386.tar.gz
+      bin: tofu-ls.exe
+    - target: win_x64
+      file: tofu-ls_Windows_x86_64.tar.gz
+      bin: tofu-ls.exe
+
+bin:
+  tofu-ls: "{{source.asset.bin}}"


### PR DESCRIPTION
### Describe your changes

Add [OpenTofu language server](https://github.com/opentofu/tofu-ls).
[OpenTofu](https://opentofu.org/) is a [FOSS fork of Terraform](https://opentofu.org/blog/the-opentofu-fork-is-now-available/).

### Issue ticket number and link

- none

### Evidence on requirement fulfillment (new packages only)

- tofu-ls is pretty new, but since OpenTofu is a fork of Terraform, I'm assuming it will get adopted pretty fast
- [nvim-lspconfig MR](https://github.com/neovim/nvim-lspconfig/pull/3874) (Merged)
- Related [nvim-lint MR](https://github.com/mfussenegger/nvim-lint/pull/801)

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->

- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots

![image](https://github.com/user-attachments/assets/7789aedc-3547-4123-baf1-ce099c8672a9)

<!-- Leave empty if not applicable -->
