### PR TITLE
bump(haskell-language-server): Update to version 2.11.0.0

### DIFF
--- a/packages/haskell-language-server/package.yaml
+++ b/packages/haskell-language-server/package.yaml
@@ -11,10 +11,10 @@ categories:
 
 source:
   # renovate:datasource=github-releases
-  id: pkg:generic/haskell/haskell-language-server@2.10.0.0
+  id: pkg:generic/haskell/haskell-language-server@2.11.0.0
   build:
     - target: unix
-      run: ghcup install hls "$VERSION" -i "$PWD"
+      run: ghcup --url-source=https://raw.githubusercontent.com/haskell/ghcup-metadata/master/ghcup-vanilla-0.0.9.yaml install hls "$VERSION" -i "$PWD"
       staged: false
       env:
         VERSION: "{{version}}"
@@ -23,7 +23,7 @@ source:
         server_9_4_8: bin/haskell-language-server-9.4.8
         server_9_6_7: bin/haskell-language-server-9.6.7
         server_9_8_4: bin/haskell-language-server-9.8.4
-        server_9_10_1: bin/haskell-language-server-9.10.1
+        server_9_10_2: bin/haskell-language-server-9.10.2
         server_9_12_2: bin/haskell-language-server-9.12.2
 
     - target: win
@@ -36,7 +36,7 @@ source:
         server_9_4_8: haskell-language-server-9.4.8.exe
         server_9_6_7: haskell-language-server-9.6.7.exe
         server_9_8_4: haskell-language-server-9.8.4.exe
-        server_9_10_1: haskell-language-server-9.10.1.exe
+        server_9_10_2: haskell-language-server-9.10.2.exe
         server_9_12_2: haskell-language-server-9.12.2.exe
 
 bin:
@@ -45,7 +45,7 @@ bin:
   haskell-language-server-9.4.8: "{{source.build.bin.server_9_4_8}}"
   haskell-language-server-9.6.7: "{{source.build.bin.server_9_6_7}}"
   haskell-language-server-9.8.4: "{{source.build.bin.server_9_8_4}}"
-  haskell-language-server-9.10.1: "{{source.build.bin.server_9_10_1}}"
+  haskell-language-server-9.10.2: "{{source.build.bin.server_9_10_2}}"
   haskell-language-server-9.12.2: "{{source.build.bin.server_9_12_2}}"
 
 neovim:


### PR DESCRIPTION
> [!NOTE]
> Blocked until `ghcup` is updated to include the latest version of HLS

### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Update Haskell Language Server to version 2.11.0.0 and the supported binary versions specified [here](https://github.com/haskell/haskell-language-server/releases/tag/2.11.0.0)

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.