### PR TITLE
bump(ty): update to v0.0.1-alpha.8

### DIFF
--- a/packages/ty/package.yaml
+++ b/packages/ty/package.yaml
@@ -11,7 +11,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:pypi/ty@0.0.1a7
+  id: pkg:pypi/ty@0.0.1a8
 
 bin:
   ty: pypi:ty


### PR DESCRIPTION
Still in alpha, updating to the latest version.