### PR TITLE
fix(alejandra): switch to cargo source instead of precompiled binaries

### DIFF
--- a/packages/alejandra/package.yaml
+++ b/packages/alejandra/package.yaml
@@ -10,12 +10,6 @@ categories:
   - Formatter
 
 source:
-  id: pkg:github/kamadorueda/alejandra@4.0.0
-  asset:
-    - target: linux_x64
-      file: alejandra-x86_64-unknown-linux-musl
-    - target: linux_arm64
-      file: alejandra-aarch64-unknown-linux-musl
-
+  id: pkg:cargo/alejandra_cli@4.0.0?repository_url=https://github.com/kamadorueda/alejandra
 bin:
-  alejandra: "{{source.asset.file}}"
+  alejandra: cargo:alejandra


### PR DESCRIPTION
Precompiled binaries only target Linux (x86_64 & arm64 musl) and don’t support other platforms like aarch64-darwin. Using the cargo source ensures cross-platform compatibility.

### Describe your changes
Switched the `source` in alejandra/package.yaml from a precompiled binary to building from source using cargo (pkg:cargo/alejandra_cli@4.0.0). This change allows installation and usage on non-Linux platforms such as aarch64 (macOS)