### PR TITLE
feat(taplo): add formatter category

### DIFF
--- a/packages/taplo/package.yaml
+++ b/packages/taplo/package.yaml
@@ -8,6 +8,7 @@ languages:
   - TOML
 categories:
   - LSP
+  - Formatter
 
 source:
   id: pkg:github/tamasfe/taplo@0.10.0


### PR DESCRIPTION
`Taplo` is also a formatter, see [this link](https://taplo.tamasfe.dev/configuration/formatter-options.html).

Setting Taplo to be a Conform formatter worked in my set up. Also updating it in Mason registry.