### PR TITLE
feat(vue-language-server): link package directory to share/

### DIFF
--- a/packages/vue-language-server/package.yaml
+++ b/packages/vue-language-server/package.yaml
@@ -20,5 +20,8 @@ schemas:
 bin:
   vue-language-server: npm:vue-language-server
 
+share:
+  vue-language-server: node_modules/@vue/language-server
+
 neovim:
   lspconfig: vue_ls


### PR DESCRIPTION
### Describe your changes
Allows the TypeScript plugin to be used like this:

```
{
  name = "@vue/typescript-plugin",
  location = vim.fn.expand("$MASON/share/vue-language-server"),
  languages = { "vue" },
}
```

### Issue ticket number and link
#10189

### Checklist before requesting a review

For some reason, I wasn't able to use Mason with a custom registry at all (perhaps a separate bug?). However, I manually symlinked the files and tested it like that, and everything worked.

<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
