### PR TITLE
Update Deno package.yaml

### DIFF
--- a/packages/deno/package.yaml
+++ b/packages/deno/package.yaml
@@ -12,6 +12,7 @@ languages:
 categories:
   - LSP
   - Runtime
+  - Linter
 
 source:
   id: pkg:github/denoland/deno@v2.3.5


### PR DESCRIPTION
deno lint isa lso available in deno. So it can also be installed as a Linter

### Describe your changes
added Linter to categories

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->
