### PR TITLE
elp: use latest otp version

### DIFF
--- a/packages/elp/package.yaml
+++ b/packages/elp/package.yaml
@@ -16,16 +16,16 @@ source:
   id: pkg:github/WhatsApp/erlang-language-platform@2025-05-29_1
   asset:
     - target: linux_x64_gnu
-      file: elp-linux-x86_64-unknown-linux-gnu-otp-26.2.tar.gz
+      file: elp-linux-x86_64-unknown-linux-gnu-otp-27.1.tar.gz
       bin: elp
     - target: linux_arm64_gnu
-      file: elp-linux-aarch64-unknown-linux-gnu-otp-26.2.tar.gz
+      file: elp-linux-aarch64-unknown-linux-gnu-otp-27.1.tar.gz
       bin: elp
     - target: darwin_x64
-      file: elp-macos-x86_64-apple-darwin-otp-26.2.tar.gz
+      file: elp-macos-x86_64-apple-darwin-otp-27.1.tar.gz
       bin: elp
     - target: darwin_arm64
-      file: elp-macos-aarch64-apple-darwin-otp-26.2.tar.gz
+      file: elp-macos-aarch64-apple-darwin-otp-27.1.tar.gz
       bin: elp
 
 schemas:


### PR DESCRIPTION
### Describe your changes
elp offers builds for different versions of Erlang/OTP. This change updates the artifacts for elp to point to the latest versions.


### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
