### PR TITLE
feat(xcode-build-server): add xcode-build-server package

### DIFF
--- a/packages/xcode-build-server/package.yaml
+++ b/packages/xcode-build-server/package.yaml
@@ -1,0 +1,22 @@
+---
+name: xcode-build-server
+description: A server to bridge Xcode build system outside of Xcode
+homepage: https://github.com/SolaWing/xcode-build-server
+licenses:
+  - MIT
+languages:
+  - Swift
+categories:
+  - LSP
+
+source:
+  id: "pkg:github/SolaWing/xcode-build-server@v1.2.0"
+  asset:
+    - target: darwin_arm64
+      file: "{{ version }}.tar.gz"
+      bin: xcode-build-server
+    - target: darwin_x64
+      file: "{{ version }}.tar.gz"
+      bin: xcode-build-server
+bin:
+  xcode-build-server: xcode-build-server


### PR DESCRIPTION
## Summary
- Add xcode-build-server package to mason-registry

## Notes
Re-creating https://github.com/mason-org/mason-registry/pull/9776 which was deleted by the original author.