### PR TITLE
feat(cspell-lsp): add cspell-lsp

### DIFF
--- a/packages/cspell-lsp/package.yaml
+++ b/packages/cspell-lsp/package.yaml
@@ -1,0 +1,18 @@
+---
+name: cspell-lsp
+description: Language Server Protocol implementation for CSpell, a spell checker for code.
+homepage: https://github.com/vlabo/cspell-lsp
+licenses:
+  - MIT
+languages: []
+categories:
+  - LSP
+
+source:
+  id: pkg:npm/@vlabo/cspell-lsp@1.1.3
+
+bin:
+  cspell-lsp: npm:cspell-lsp
+
+neovim:
+  lspconfig: cspell_ls


### PR DESCRIPTION
### Describe your changes
Adding the cspell-lsp to the registry

### Issue ticket number and link
https://github.com/vlabo/cspell-lsp/issues/14

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

1. lspconfig already has configuration for cspell-lsp: 
  https://github.com/neovim/nvim-lspconfig/blob/master/lsp/cspell_ls.lua


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested the installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->

![image](https://github.com/user-attachments/assets/a5404297-76d5-4657-9924-1e236122f840)

![image](https://github.com/user-attachments/assets/53463672-c5f8-487c-9cdd-d3d5d571832c)
