### PR TITLE
feat: add emmylua-codeformat

### DIFF
--- a/packages/emmylua-codeformat/package.yaml
+++ b/packages/emmylua-codeformat/package.yaml
@@ -1,0 +1,32 @@
+---
+name: emmylua-codeformat
+description: Fast, powerful, and feature-rich Lua formatting and checking tool.
+homepage: https://github.com/CppCXY/EmmyLuaCodeStyle
+licenses:
+  - MIT
+languages:
+  - Lua
+categories:
+  - Formatter
+
+source:
+  id: pkg:github/CppCXY/EmmyLuaCodeStyle@1.5.6
+  asset:
+    - target: darwin_arm64
+      file: darwin-arm64.tar.gz
+      bin: darwin-arm64/bin/CodeFormat
+    - target: darwin_x64
+      file: darwin-x64.tar.gz
+      bin: darwin-x64/bin/CodeFormat
+    - target: linux_arm64_gnu
+      file: linux-aarch64.tar.gz
+      bin: linux-aarch64/bin/CodeFormat
+    - target: linux_x64_gnu
+      file: linux-x64.tar.gz
+      bin: linux-x64/bin/CodeFormat
+    - target: win_x64
+      file: win32-x64.zip
+      bin: win32-x64/bin/CodeFormat.exe
+
+bin:
+  emmylua-codeformat: "{{source.asset.bin}}"

--- a/packages/emmylua-codeformat/package.yaml
+++ b/packages/emmylua-codeformat/package.yaml
@@ -1,6 +1,8 @@
 ---
 name: emmylua-codeformat
-description: Fast, powerful, and feature-rich Lua formatting and checking tool.
+description: |
+  Fast, powerful, and feature-rich Lua formatting and checking tool. 
+  This tool is already bundled with lua_ls, so you don’t need it if you’re using lua_ls.
 homepage: https://github.com/CppCXY/EmmyLuaCodeStyle
 licenses:
   - MIT


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

I would like to add the EmmyLuaCodeStyle formatter, which is also included in lua_ls.

https://github.com/CppCXY/EmmyLuaCodeStyle

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

![swappy-20250702-102015](https://github.com/user-attachments/assets/5b3741d0-ebf7-4478-99fc-99294d6bf4ab)


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
