### PR TITLE
feat(bacon-ls): add `neovim.lspconfig` property

### DIFF
--- a/packages/bacon-ls/package.yaml
+++ b/packages/bacon-ls/package.yaml
@@ -14,3 +14,6 @@ source:
 
 bin:
   bacon-ls: cargo:bacon-ls
+
+neovim:
+  lspconfig: bacon_ls


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Added `neovim.lspconfig: bacon_ls` so [`mason-lspconfig`](github.com/mason-org/mason-lspconfig.nvim) can install [`bacon-ls`](github.com/crisidev/bacon-ls).

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
