### PR TITLE
fix: deprecate `chrome-debug-adapter` & `node-debug2-adapter`

### DIFF
--- a/packages/chrome-debug-adapter/package.yaml
+++ b/packages/chrome-debug-adapter/package.yaml
@@ -10,6 +10,10 @@ languages:
 categories:
   - DAP
 
+deprecation:
+  since: v4.13.0
+  message: This adapter has been superseded by the js-debug-adapter.
+
 source:
   # renovate:datasource=github-tags
   id: pkg:github/Microsoft/vscode-chrome-debug@v4.13.0

--- a/packages/node-debug2-adapter/package.yaml
+++ b/packages/node-debug2-adapter/package.yaml
@@ -10,6 +10,10 @@ languages:
 categories:
   - DAP
 
+deprecation:
+  since: v1.43.0
+  message: This adapter has been superseded by the js-debug-adapter.
+
 source:
   # renovate:datasource=github-tags
   id: pkg:github/microsoft/vscode-node-debug2@v1.43.0


### PR DESCRIPTION
### Describe your changes
[chrome-debug-adapter](https://github.com/Microsoft/vscode-chrome-debug) and [node-debug2-adapter](http://github.com/microsoft/vscode-node-debug2) have both been archived years ago and have been superseded with the [js-debug-adapter](https://github.com/microsoft/vscode-js-debug) (which is already available on mason).

