### PR TITLE
feat(add): package vscode-java-dependency

### DIFF
--- a/packages/vscode-java-dependency/package.yaml
+++ b/packages/vscode-java-dependency/package.yaml
@@ -7,7 +7,7 @@ licenses:
 languages:
   - Java
 categories:
-  - LSP
+  - Runtime
 
 source:
   id: pkg:openvsx/vscjava/vscode-java-dependency@0.24.1

--- a/packages/vscode-java-dependency/package.yaml
+++ b/packages/vscode-java-dependency/package.yaml
@@ -1,0 +1,18 @@
+---
+name: vscode-java-dependency
+description: Visual Studio Code extension for managing Java projects, dependencies, and exporting JAR files
+homepage: https://github.com/Microsoft/vscode-java-dependency
+licenses:
+  - MIT
+languages:
+  - Java
+categories:
+  - Runtime
+
+source:
+  id: pkg:openvsx/vscjava/vscode-java-dependency@0.24.1
+  download:
+    file: https://open-vsx.org/api/vscjava/vscode-java-dependency/0.24.1/file/vscjava.vscode-java-dependency-0.24.1.vsix
+
+share:
+  vscode-java-dependency/: extension/server/

--- a/packages/vscode-java-dependency/package.yaml
+++ b/packages/vscode-java-dependency/package.yaml
@@ -12,7 +12,7 @@ categories:
 source:
   id: pkg:openvsx/vscjava/vscode-java-dependency@0.24.1
   download:
-    file: https://open-vsx.org/api/vscjava/vscode-java-dependency/0.24.1/file/vscjava.vscode-java-dependency-0.24.1.vsix
+    file: vscjava.vscode-java-dependency-0.24.1.vsix
 
 share:
   vscode-java-dependency/: extension/server/

--- a/packages/vscode-java-dependency/package.yaml
+++ b/packages/vscode-java-dependency/package.yaml
@@ -12,7 +12,7 @@ categories:
 source:
   id: pkg:openvsx/vscjava/vscode-java-dependency@0.24.1
   download:
-    file: vscjava.vscode-java-dependency-0.24.1.vsix
+    file: vscjava.vscode-java-dependency-{{version}}.vsix
 
 share:
   vscode-java-dependency/: extension/server/

--- a/packages/vscode-java-dependency/package.yaml
+++ b/packages/vscode-java-dependency/package.yaml
@@ -7,7 +7,7 @@ licenses:
 languages:
   - Java
 categories:
-  - Runtime
+  - LSP
 
 source:
   id: pkg:openvsx/vscjava/vscode-java-dependency@0.24.1


### PR DESCRIPTION
### Describe your changes
This pull request introduces the `vscode-java-dependency` package to the registry. This package is a crucial dependency for a new Neovim plugin I am developing called [java-deps.nvim](https://github.com/g0ne150/java-deps.nvim).

The `java-deps.nvim` plugin aims to provide functionality similar to the popular VS Code extension [vscode-java-dependency](https://open-vsx.org/extension/vscjava/vscode-java-dependency), allowing users to view Java projects and dependencies. The main functionality of this plugin has already been developed and tested.

For `java-deps.nvim` to work correctly, it requires the language server and associated utilities provided by `vscode-java-dependency`. Adding this package to `mason-registry` will allow users to easily and automatically install this dependency, ensuring a smooth setup process for the plugin.

The provided `package.yaml` is configured to download the extension from the Open VSX marketplace and extract the necessary server files.

### Evidence on requirement fulfillment (new packages only)
`vscode-java-dependency` is a widely adopted and officially maintained extension by Microsoft for Java development in Visual Studio Code. Its popularity and utility are demonstrated on its marketplace page, which indicates a strong and active user base. This serves as evidence that the tool is valuable and necessary for the broader Java development community.

### Checklist before requesting a review
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.