### PR TITLE
added 'neovim.lspconfig' mapping for qmlls

### DIFF
--- a/packages/qmlls/package.yaml
+++ b/packages/qmlls/package.yaml
@@ -26,3 +26,6 @@ source:
 
 bin:
   qmlls: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: qmlls


### PR DESCRIPTION
### Describe your changes
Added lspconfig mapping for qmlls to have it be automatically enabled with mason-lspconfig

### Issue ticket number and link

### Evidence on requirement fulfillment (new packages only)

### Checklist before requesting a review
- [X] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.

### Screenshots
