### PR TITLE
Fixes the renovate PR #10092 to bump jdtls

### DIFF
--- a/packages/jdtls/package.yaml
+++ b/packages/jdtls/package.yaml
@@ -39,7 +39,7 @@ share:
   jdtls/lombok.jar: lombok.jar
   jdtls/plugins/: plugins/
   jdtls/plugins/org.eclipse.equinox.launcher.jar: plugins/org.eclipse.equinox.launcher_1.7.0.v20250519-0528.jar
-  dtls/config/: "{{source.download.config}}"
+  jdtls/config/: "{{source.download.config}}"
 
 neovim:
   lspconfig: jdtls


### PR DESCRIPTION
### Describe your changes
Update jdtls to  1.48.0

### Issue ticket number and link


### Evidence on requirement fulfillment (new packages only)

### Checklist before requesting a review

- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
i