### PR TITLE
feat: add vscode-pde

### DIFF
--- a/packages/vscode-pde/package.yaml
+++ b/packages/vscode-pde/package.yaml
@@ -1,0 +1,24 @@
+---
+name: vscode-pde
+description: |
+  This extension works as a plugin of Language Support for eclipse.jtl.ls. It provides the
+  ability to import Eclipse PDE projects and set up the correct target platforms.
+
+  The extension will be build from source and requires that JAVA_HOME is set to the path to JDK 21.
+homepage: https://github.com/testforstephen/vscode-pde
+licenses:
+  - EPL-2.0
+languages:
+  - Java
+categories: []
+
+source:
+  # version behind: https://github.com/testforstephen/vscode-pde/pull/58
+  id: pkg:github/PMarinov1994/vscode-pde@eb044c94527df73a7bb402b1508eb97397c254c9
+  build:
+    run: |
+      npm ci
+      npm run build-server
+
+share:
+  vscode-pde/: server/


### PR DESCRIPTION
### Describe your changes

The extension for eclipse.jdt.ls (Java language server) provides Eclipse PDE support and is required for the development of eclipse.jdt.ls itself.

### Evidence on requirement fulfillment (new packages only)

[The contribution guide of eclipse.jdt.ls](https://github.com/eclipse-jdtls/eclipse.jdt.ls/blob/main/CONTRIBUTING.md) mentions the requirement of this package. Once upon a time I wrote a Neovim plugin for it because I didn't know about Mason at the time (linked in the contribution guide) but I want people to go the best place for managing Neovim LSP/DAP/… extensions.

### Checklist before requesting a review

- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
