### PR TITLE
bump(java-debug-adapter): update to v0.58.2

### DIFF
--- a/packages/java-debug-adapter/package.yaml
+++ b/packages/java-debug-adapter/package.yaml
@@ -10,10 +10,10 @@ categories:
   - DAP
 
 source:
-  id: pkg:openvsx/vscjava/vscode-java-debug@0.58.1
+  id: pkg:openvsx/vscjava/vscode-java-debug@0.58.2
   download:
     file: vscjava.vscode-java-debug-{{version}}.vsix
 
 share:
   java-debug-adapter/: extension/server/
-  java-debug-adapter/com.microsoft.java.debug.plugin.jar: extension/server/com.microsoft.java.debug.plugin-0.53.1.jar
+  java-debug-adapter/com.microsoft.java.debug.plugin.jar: extension/server/com.microsoft.java.debug.plugin-0.53.2.jar


### PR DESCRIPTION
### Describe your changes
Update java-debug-adapter to v0.58.2

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)

See https://open-vsx.org/extension/vscjava/vscode-java-debug

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ x] I have successfully tested installation of the package.
- [ x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
