### PR TITLE
fix(wgsl-analyzer): Make Renovate update wgsl-analyzer releases

### DIFF
--- a/packages/wgsl-analyzer/package.yaml
+++ b/packages/wgsl-analyzer/package.yaml
@@ -11,6 +11,7 @@ categories:
   - LSP
 
 source:
+  # renovate:versioning=loose
   id: pkg:github/wgsl-analyzer/wgsl-analyzer@v0.9.11
   asset:
     - target: [darwin_arm64, darwin_x64]


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
A `versioning:loose` renovate directive has been added to the `wgsl-analyzer` package.yaml. This is done because the release versioning scheme has been changed from semantic versioning to a date based system since the original introduction of the `wgsl-analyzer` package (see https://github.com/wgsl-analyzer/wgsl-analyzer/releases). The same `versioning=loose` directive has been found in other packages with date based release schemes (e.g. rust-analyzer), so this seemed like the most straightforward solution.

I have not tested this in Neovim, but this does not change the `wgsl-analyzer` package in any meaningful way. It does, however, enable the renovate bot to update the `wgsl-analyzer` package when new releases are available, so I have tested this locally with renovate. The output of renovate from a dry run with `LOG_LEVEL=debug` can be found below.

[debug.txt](https://github.com/user-attachments/files/21449269/debug.txt)

### Issue ticket number and link
<!-- Leave empty if not available -->
#10028

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
