### PR TITLE
bump(wgsl-analyzer): update to v2025

### DIFF
--- a/packages/wgsl-analyzer/package.yaml
+++ b/packages/wgsl-analyzer/package.yaml
@@ -36,6 +36,20 @@ source:
       file: wgsl-analyzer-aarch64-pc-windows-msvc.zip
       bin: wgsl-analyzer.exe
 
+  version_overrides:
+    - constraint: semver:<=v0.9.11
+      id: pkg:github/wgsl-analyzer/wgsl-analyzer@v0.9.11
+      asset:
+        - target: [darwin_arm64, darwin_x64]
+          file: wgsl-analyzer-darwin-x64
+          bin: wgsl-analyzer-darwin-x64
+        - target: linux_x64
+          file: wgsl-analyzer-linux-x64
+          bin: wgsl-analyzer-linux-x64
+        - target: win_x64
+          file: wgsl-analyzer-win32-x64.exe
+          bin: wgsl-analyzer-win32-x64.exe
+
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/wgsl-analyzer/wgsl-analyzer/{{version}}/editors/code/package.json
 

--- a/packages/wgsl-analyzer/package.yaml
+++ b/packages/wgsl-analyzer/package.yaml
@@ -12,20 +12,35 @@ categories:
 
 source:
   # renovate:versioning=loose
-  id: pkg:github/wgsl-analyzer/wgsl-analyzer@v0.9.11
+  id: pkg:github/wgsl-analyzer/wgsl-analyzer@2025-06-28
   asset:
-    - target: [darwin_arm64, darwin_x64]
-      file: wgsl-analyzer-darwin-x64
-    - target: linux_x64
-      file: wgsl-analyzer-linux-x64
+    - target: linux_x64_gnu
+      file: wgsl-analyzer-x86_64-unknown-linux-gnu.gz
+      bin: wgsl-analyzer-x86_64-unknown-linux-gnu
+    - target: linux_arm64_gnu
+      file: wgsl-analyzer-aarch64-unknown-linux-gnu.gz
+      bin: wgsl-analyzer-aarch64-unknown-linux-gnu
+    - target: linux_x64_musl
+      file: wgsl-analyzer-x86_64-unknown-linux-musl.gz
+      bin: wgsl-analyzer-x86_64-unknown-linux-musl
+    - target: darwin_x64
+      file: wgsl-analyzer-x86_64-apple-darwin.gz
+      bin: wgsl-analyzer-x86_64-apple-darwin
+    - target: darwin_arm64
+      file: wgsl-analyzer-aarch64-apple-darwin.gz
+      bin: wgsl-analyzer-aarch64-apple-darwin
     - target: win_x64
-      file: wgsl-analyzer-win32-x64.exe
+      file: wgsl-analyzer-x86_64-pc-windows-msvc.zip
+      bin: wgsl-analyzer.exe
+    - target: win_arm64
+      file: wgsl-analyzer-aarch64-pc-windows-msvc.zip
+      bin: wgsl-analyzer.exe
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/wgsl-analyzer/wgsl-analyzer/{{version}}/editors/code/package.json
 
 bin:
-  wgsl_analyzer: "{{source.asset.file}}"
+  wgsl-analyzer: "{{source.asset.bin}}"
 
 neovim:
   lspconfig: wgsl_analyzer


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Bumps the `wgsl-analyzer` version the same way that renovatebot does in https://github.com/mason-org/mason-registry/pull/10977, but also updates the `assets` mappings to the types in the newest releases.

The `bin` mapping is also changed from `wgsl_analyzer` to `wgsl-analyzer` to reflect the config for `wgsl-analyzer` in lspconfig (see https://github.com/neovim/nvim-lspconfig/blob/master/lsp/wgsl_analyzer.lua). This may cause a breaking change in some lsp configs using mason, but should also enable `wgsl-analyzer` to work without any changes to the lsp config `cmd` value on a new config.

### Issue ticket number and link
#10028 

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [X] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
