### PR TITLE
docs: more explicit requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@
 At least one of the following conditions MUST be fulfilled for new packages to be added to the registry.
 
 1. At least 100 stars on GitHub.
-1. Evidence that the tool has a relevant user base, such as VSCode marketplace downloads.
+1. At least 5000 VSCode marketplace downloads.
 1. Be approved at [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig).
 1. Have a credible authority vouch for it, e.g., the tool is officially recommended by maintainers of the language.
 


### PR DESCRIPTION
### Describe your changes
In various PRs, we had discussions what "a relevant number of users" means in regard to VS Code Marketplace downloads. Specifying a concrete number should be helpful to make things clearer to people considering adding a new package.

I chose the number 5000, because of VS Code's large user base, and because downloads are done passively, as opposed to the active act of starring a repo on GitHub. It's more of a ballpark, so a tool with 4995 downloads would still be fine of course, but ~300 downloads are imho not sufficient to count as a relevant user base. 

