### PR TITLE
bump(fennel-ls): update to 0.2.1-2 and remove ci skip

### DIFF
--- a/packages/fennel-ls/package.yaml
+++ b/packages/fennel-ls/package.yaml
@@ -10,20 +10,10 @@ categories:
   - LSP
 
 source:
-  id: pkg:luarocks/fennel-ls@0.2.1-1
+  id: pkg:luarocks/fennel-ls@0.2.1-2
 
 bin:
   fennel-ls: luarocks:fennel-ls
 
 neovim:
   lspconfig: fennel_ls
-
-ci_skip:
-  # Per xerool, the author of fennel-ls:
-  #
-  #     Eventually they'll .. create a PR for bumping fennel-ls, and when that PR's CI inevitably fails,
-  #     we'll have to convince them that it's okay to be broken in windows.
-  #
-  # See: https://todo.sr.ht/~xerool/fennel-ls/54#event-419872
-  #
-  - win_x64


### PR DESCRIPTION
### Describe your changes
The `fennel-ls` rockspec on luarocks now declares that it doesn't support windows,
so that information doesn't need to be duplicated in mason-repository.

### Issue ticket number and link
https://github.com/mason-org/mason-registry/pull/11047

https://luarocks.org/manifests/xerool/fennel-ls-0.2.1-2.rockspec