### PR TITLE
feat(docker-language-server): add lsp server

### DIFF
--- a/packages/docker-language-server/package.yaml
+++ b/packages/docker-language-server/package.yaml
@@ -1,0 +1,20 @@
+---
+name: docker-language-server
+description: Language server for Dockerfiles, Compose files, and Bake files.
+homepage: https://github.com/docker/docker-language-server
+licenses:
+  - MIT
+languages:
+  - Docker
+categories:
+  - LSP
+
+source:
+  id: pkg:golang/github.com/docker/docker-language-server/cmd/docker-language-server@v0.14.0
+
+bin:
+  docker-language-server: golang:docker-language-server
+
+neovim:
+  lspconfig: docker-language-server
+

--- a/packages/docker-language-server/package.yaml
+++ b/packages/docker-language-server/package.yaml
@@ -3,17 +3,30 @@ name: docker-language-server
 description: Language server for Dockerfiles, Compose files, and Bake files.
 homepage: https://github.com/docker/docker-language-server
 licenses:
-  - MIT
+  - Apache-2.0
 languages:
   - Docker
 categories:
   - LSP
 
 source:
-  id: pkg:golang/github.com/docker/docker-language-server/cmd/docker-language-server@v0.14.0
+  id: pkg:github/docker/docker-language-server@v0.14.0
+  asset:
+    - target: darwin_x64
+      file: docker-language-server-darwin-amd64-{{version}}
+    - target: darwin_arm64
+      file: docker-language-server-darwin-arm64-{{version}}
+    - target: linux_arm64_gnu
+      file: docker-language-server-linux-arm64-{{version}}
+    - target: linux_x64_gnu
+      file: docker-language-server-linux-amd64-{{version}}
+    - target: win_arm64
+      file: docker-language-server-windows-arm64-{{version}}.exe
+    - target: win_x64
+      file: docker-language-server-windows-amd64-{{version}}.exe
 
 bin:
-  docker-language-server: golang:docker-language-server
+  docker-language-server: {{source.asset.file}}
 
 neovim:
   lspconfig: docker-language-server

--- a/packages/docker-language-server/package.yaml
+++ b/packages/docker-language-server/package.yaml
@@ -26,7 +26,7 @@ source:
       file: docker-language-server-windows-amd64-{{version}}.exe
 
 bin:
-  docker-language-server: {{source.asset.file}}
+  docker-language-server: "{{source.asset.file}}"
 
 neovim:
   lspconfig: docker-language-server


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Added docker-language-server

### Issue ticket number and link
<!-- Leave empty if not available -->
#11059

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->
- [ ] At least 100 stars on GitHub.
  - at the moment 81 https://github.com/docker/docker-language-server
- [ ] Evidence that the tool has a relevant user base, such as VSCode marketplace downloads.
  - Not sure here. Package is published by docker org
- [x] Be approved at [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig).
  - Already merged into master https://github.com/neovim/nvim-lspconfig/commit/e3d837b
- [x] Have a credible authority vouch for it, e.g., the tool is officially recommended by maintainers of the language.
  - Package is published by docker org on 16 july because of that usage is inevitable 

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
  Successfully started server inside nvim and got diagnostics for Dockerfile from server
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
