### PR TITLE
fix(docker-language-server): lspconfig server name

### DIFF
--- a/packages/docker-language-server/package.yaml
+++ b/packages/docker-language-server/package.yaml
@@ -29,5 +29,5 @@ bin:
   docker-language-server: "{{source.asset.file}}"
 
 neovim:
-  lspconfig: docker-language-server
+  lspconfig: docker_language_server
 


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Mistake in previous PR – incorrect lspconfig name
https://github.com/neovim/nvim-lspconfig/commit/e3d837b#diff-0e52ccaf020d4b83905c5231e4a62e95a1d06298b97e13bd97ef241c6f155fff

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
