### PR TITLE
bump elp version 27.1 to 27.3

### DIFF
--- a/packages/elp/package.yaml
+++ b/packages/elp/package.yaml
@@ -16,16 +16,16 @@ source:
   id: pkg:github/WhatsApp/erlang-language-platform@2025-07-21
   asset:
     - target: linux_x64_gnu
-      file: elp-linux-x86_64-unknown-linux-gnu-otp-27.1.tar.gz
+      file: elp-linux-x86_64-unknown-linux-gnu-otp-27.3.tar.gz
       bin: elp
     - target: linux_arm64_gnu
-      file: elp-linux-aarch64-unknown-linux-gnu-otp-27.1.tar.gz
+      file: elp-linux-aarch64-unknown-linux-gnu-otp-27.3.tar.gz
       bin: elp
     - target: darwin_x64
-      file: elp-macos-x86_64-apple-darwin-otp-27.1.tar.gz
+      file: elp-macos-x86_64-apple-darwin-otp-27.3.tar.gz
       bin: elp
     - target: darwin_arm64
-      file: elp-macos-aarch64-apple-darwin-otp-27.1.tar.gz
+      file: elp-macos-aarch64-apple-darwin-otp-27.3.tar.gz
       bin: elp
 
 schemas:


### PR DESCRIPTION
### Describe your changes
This PR updates the Erlang Language Platform version used by Mason.

The archive for version 27.1 is no longer available under the tag 2025-07-21, which is the tag Mason uses to install the server. To ensure installation works correctly, I bumped the version to 27.3, which is available under the same tag.

https://github.com/WhatsApp/erlang-language-platform/releases/tag/2025-07-21

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
<img width="1486" height="183" alt="image" src="https://github.com/user-attachments/assets/879b394a-bc78-4589-b421-1da65e586583" />
Failed to download file "https://github.com/whatsapp/erlang-language-platform/releases/download/2025-07-21/elp-linux-x86_64-unknown-linux-gnu-otp-27.1.tar.gz".

