### PR TITLE
bump(ocaml-lsp): update to v1.23.0

### DIFF
--- a/packages/ocaml-lsp/package.yaml
+++ b/packages/ocaml-lsp/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:opam/ocaml-lsp-server@1.22.0
+  id: pkg:opam/ocaml-lsp-server@1.23.0
 
 bin:
   ocamllsp: opam:ocamllsp


### PR DESCRIPTION
update ocaml-lsp to v1.23.0 because v1.22.0 has some issues like https://github.com/ocaml/ocaml-lsp/issues/1531



https://github.com/ocaml/ocaml-lsp/releases/tag/1.23.0