### PR TITLE
bump(sonarlint-language-server): update to 4.28.0

### DIFF
--- a/packages/sonarlint-language-server/package.yaml
+++ b/packages/sonarlint-language-server/package.yaml
@@ -29,9 +29,9 @@ categories:
   - Linter
 
 source:
-  id: pkg:github/SonarSource/sonarlint-vscode@4.22.0%2B77643
+  id: pkg:github/SonarSource/sonarlint-vscode@4.28.0%2B78085
   asset:
-    file: sonarlint-vscode-4.22.0.vsix
+    file: sonarlint-vscode-4.28.0.vsix
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/SonarSource/sonarlint-vscode/{{version}}/package.json


### PR DESCRIPTION
### Describe your changes

update sonarlint-language server to 4.28.0

### Issue ticket number and link

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots

`:LspInfo` excerpt:

```
vim.lsp: Active Clients ~
- sonarlint.nvim (id: 2)
  - Version: 3.28.0.76421
  - Root directory: /path/to//sonarlint-language-server
  - Command: { "/usr/lib/jvm/java-17-openjdk/bin/java", "-jar", "~/.local/share/nvim/mason/packages/sonarlint-language-server/extension/server/sonarlint-ls.jar", "-stdio", "-analyzers", "~/.local/share/nvim/mason/share/sonarlint-analyzers/csharpenterprise.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonarcsharp.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonargo.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonarhtml.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonariac.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonarjava.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonarjavasymbolicexecution.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonarjs.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonarlintomnisharp.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonarphp.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonarpython.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonartext.jar", "~/.local/share/nvim/mason/share/sonarlint-analyzers/sonarxml.jar" }
  - Settings: {
      sonarlint = {
        rules = vim.empty_dict()
      }
    }
  - Attached buffers: 1
```
