### PR TITLE
fix 'rust-analyzer@2025-08-11' to 'rust-analyzer@2025-08-04'

### DIFF
--- a/packages/rust-analyzer/package.yaml
+++ b/packages/rust-analyzer/package.yaml
@@ -15,7 +15,7 @@ categories:
 
 source:
   # renovate:versioning=loose
-  id: pkg:github/rust-lang/rust-analyzer@2025-08-11
+  id: pkg:github/rust-lang/rust-analyzer@2025-08-04
   asset:
     - target: linux_x64_gnu
       file: rust-analyzer-x86_64-unknown-linux-gnu.gz


### PR DESCRIPTION
As @0xMaze mentioned in issue [#2010]((https://github.com/mason-org/mason.nvim/issues/2010), the incorrect URL causes the download to fail.

Therefore, I updated the `URL` for `Rust Analyzer` in `package.yml` from 'rust-analyzer@2025-08-11' to 'rust-analyzer@2025-08-04'.