### PR TITLE
feat: add codebook

### DIFF
--- a/packages/codebook/package.yaml
+++ b/packages/codebook/package.yaml
@@ -1,0 +1,50 @@
+---
+name: codebook
+description: An unholy spell checker for code.
+homepage: https://github.com/blopker/codebook
+licenses:
+  - MIT
+languages:
+  - C
+  - CSS
+  - Go
+  - HTML
+  - Haskell
+  - Java
+  - JavaScript
+  - Lua
+  - Markdown
+  - PHP
+  - Plain
+  - Python
+  - Ruby
+  - Rust
+  - TOML
+  - TypeScript
+categories:
+  - LSP
+
+source:
+  id: pkg:github/blopker/codebook@v0.3.8
+  asset:
+    - target: linux_x64_gnu
+      file: codebook-lsp-x86_64-unknown-linux-musl.tar.gz
+      bin: codebook-lsp
+    - target: linux_arm64_gnu
+      file: codebook-lsp-aarch64-unknown-linux-musl.tar.gz
+      bin: codebook-lsp
+    - target: darwin_x64
+      file: codebook-lsp-x86_64-apple-darwin.tar.gz
+      bin: codebook-lsp
+    - target: darwin_arm64
+      file: codebook-lsp-aarch64-apple-darwin.tar.gz
+      bin: codebook-lsp
+    - target: win_x64
+      file: codebook-lsp-x86_64-pc-windows-msvc.zip
+      bin: codebook-lsp.exe
+
+bin:
+  codebook-lsp: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: codebook


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Added codebook that has been recently added to neovim's lspconfig repo.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->
https://github.com/neovim/nvim-lspconfig/blob/master/lsp/codebook.lua

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
<img width="1606" height="198" alt="codebook" src="https://github.com/user-attachments/assets/add8ec45-2dd2-4150-9ad7-64f1ccb37f40" />