### PR TITLE
feat(tree-sitter-cli): add native macOS arm64 build.

### DIFF
--- a/packages/tree-sitter-cli/package.yaml
+++ b/packages/tree-sitter-cli/package.yaml
@@ -13,9 +13,12 @@ categories:
 source:
   id: pkg:github/tree-sitter/tree-sitter@v0.25.8
   asset:
-    - target: [darwin_x64, darwin_arm64]
+    - target: darwin_x64
       file: tree-sitter-macos-x64.gz
       bin: tree-sitter-macos-x64
+    - target: darwin_arm64
+      file: tree-sitter-macos-arm64.gz
+      bin: tree-sitter-macos-arm64
     - target: linux_x64
       file: tree-sitter-linux-x64.gz
       bin: tree-sitter-linux-x64


### PR DESCRIPTION
Currently the tree-sitter-cli provides x64 binary for both macOS arm64 and macOS x64, which is weird for me. This makes treesitter-cli totally unusable with neovim nvim-treesitter as the compiled parser will be incompatible with neovim itself. This PR updates the registry to use the official builds for arm64 from treesitter's github release.
