### PR TITLE
feat(copilot): add nvim's lspconfig name

### DIFF
--- a/packages/copilot-language-server/package.yaml
+++ b/packages/copilot-language-server/package.yaml
@@ -13,3 +13,6 @@ source:
 
 bin:
   copilot-language-server: npm:copilot-language-server
+
+neovim:
+  lspconfig: copilot


### PR DESCRIPTION
### Describe your changes
Add lspconfig's name of `copilot-language-server`: `copilot`

Refer to https://github.com/neovim/nvim-lspconfig/blob/master/lsp/copilot.lua