### PR TITLE
feat(hadolint): Adds support for Darwin arm64 back **PLEASE READ NOTE**

### DIFF
--- a/packages/hadolint/package.yaml
+++ b/packages/hadolint/package.yaml
@@ -14,6 +14,8 @@ source:
   asset:
     - target: darwin_x64
       file: hadolint-Darwin-x86_64
+    - target: darwin_arm64
+      file: hadolint-Macos-arm64
     - target: linux_x64
       file: hadolint-Linux-x86_64
     - target: linux_arm64

--- a/packages/hadolint/package.yaml
+++ b/packages/hadolint/package.yaml
@@ -15,7 +15,7 @@ source:
     - target: darwin_x64
       file: hadolint-Darwin-x86_64
     - target: darwin_arm64
-      file: hadolint-Macos-arm64
+      file: hadolint-macOS-arm64
     - target: linux_x64
       file: hadolint-Linux-x86_64
     - target: linux_arm64


### PR DESCRIPTION
arm64 support was removed in [PR](https://github.com/mason-org/mason-registry/pull/10075/). This PR adds that support back.

**NOTE**
** This [PR](https://github.com/mason-org/mason-registry/pull/11425) must be merged first before this PR. **

### Describe your changes
Adding arm64 support for Hadolint back.

### Issue ticket number and link
https://github.com/mason-org/mason-registry/pull/11425

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
