### PR TITLE
Add package rpm-spec-language-server

### DIFF
--- a/packages/rpm-spec-language-server/package.yaml
+++ b/packages/rpm-spec-language-server/package.yaml
@@ -1,0 +1,19 @@
+---
+name: rpm-spec-language-server
+description: Language server protocol (LSP) support for RPM Spec files.
+homepage: https://github.com/dcermak/rpm-spec-language-server
+licenses:
+  - GPL-2.0
+languages:
+  - Spec
+categories:
+  - LSP
+
+source:
+  id: pkg:pypi/rpm-spec-language-server@0.0.1
+
+bin:
+  rpm_lsp_server: pypi:rpm_lsp_server
+
+neovim:
+  lspconfig: rpmspec

--- a/packages/rpm_lsp_server/package.yaml
+++ b/packages/rpm_lsp_server/package.yaml
@@ -1,5 +1,5 @@
 ---
-name: rpm-spec-language-server
+name: rpm_lsp_server
 description: Language server protocol (LSP) support for RPM Spec files.
 homepage: https://github.com/dcermak/rpm-spec-language-server
 licenses:


### PR DESCRIPTION
### Describe your changes
New package with LSP for RPMs spec-files.

### Issue ticket number and link

### Evidence on requirement fulfillment (new packages only)
The LSP is present at `nvim-lspconfig`: https://github.com/neovim/nvim-lspconfig/blob/master/lsp/rpmspec.lua

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

Successful start of LSP in Neovim.

### Screenshots
