### PR TITLE
feat(goimports-reviser): Add linux-arm64 binary.

### DIFF
--- a/packages/goimports-reviser/package.yaml
+++ b/packages/goimports-reviser/package.yaml
@@ -24,6 +24,9 @@ source:
     - target: linux_x64
       file: goimports-reviser_{{ version | strip_prefix "v" }}_linux_amd64.tar.gz
       bin: goimports-reviser
+    - target: linux_arm64
+      file: goimports-reviser_{{ version | strip_prefix "v" }}_linux_arm64.tar.gz
+      bin: goimports-reviser
     - target: win_x64
       file: goimports-reviser_{{ version | strip_prefix "v" }}_windows_amd64.tar.gz
       bin: goimports-reviser.exe


### PR DESCRIPTION
`goimports-reviser` started releasing linux-arm64 binary from v3.9.1 onwards:
    https://github.com/incu6us/goimports-reviser/releases/tag/v3.9.1

Let's update the registry entry to include the same.

### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Add linux-arm64 binary for `goimports-reviser`

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
<img width="697" height="593" alt="Screenshot 2025-09-12 at 7 23 53 PM" src="https://github.com/user-attachments/assets/37eb74b9-8e01-49d9-9624-96fdeabce848" />

1. `goimports-reviser` listed in the `Installed` list
2. `uname -a` output captured in the bottom panel via `:lua vim.system({"uname", "-a"})`