### PR TITLE
Allow the Docker Language Server to be installed on musl systems

### DIFF
--- a/packages/docker-language-server/package.yaml
+++ b/packages/docker-language-server/package.yaml
@@ -18,7 +18,11 @@ source:
       file: docker-language-server-darwin-arm64-{{version}}
     - target: linux_arm64_gnu
       file: docker-language-server-linux-arm64-{{version}}
+    - target: linux_arm64_musl
+      file: docker-language-server-linux-arm64-{{version}}
     - target: linux_x64_gnu
+      file: docker-language-server-linux-amd64-{{version}}
+    - target: linux_x64_musl
       file: docker-language-server-linux-amd64-{{version}}
     - target: win_arm64
       file: docker-language-server-windows-arm64-{{version}}.exe


### PR DESCRIPTION
### Describe your changes

From testing, the Docker Language Server does run on Alpine Linux so we should add targets for musl in the configuration file.

### Issue ticket number and link

- #11361

### Evidence on requirement fulfillment (new packages only)

This is not a net new package.

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots

<img width="545" height="545" alt="image" src="https://github.com/user-attachments/assets/6253e4ce-8c98-4110-88f3-a87679a0b937" />