### PR TITLE
feat(kubescape): add kubescape linter/scanner

### DIFF
--- a/packages/kubescape/package.yaml
+++ b/packages/kubescape/package.yaml
@@ -1,0 +1,35 @@
+---
+name: kubescape
+description: |
+  Kubescape is an open-source Kubernetes security platform for your IDE, CI/CD pipelines, and clusters. It includes risk analysis, security, compliance, and misconfiguration scanning, saving Kubernetes users and administrators precious time, effort, and resources. 
+homepage: https://kubescape.io/
+licenses:
+  - Apache-2.0
+languages:
+  - Helm
+  - YAML
+categories:
+  - Linter
+  - Runtime
+
+source:
+  id: pkg:github/kubescape/kubescape@v3.0.41
+  asset:
+    - target: darwin_x64
+      file: kubescape-macos-latest.tar.gz
+      bin: kubescape-macos-latest
+    - target: darwin_arm64
+      file: kubescape-arm64-macos-latest.tar.gz
+      bin: kubescape-arm64-macos-latest
+    - target: linux_x64
+      file:  kubescape-ubuntu-latest.tar.gz
+      bin:  kubescape-ubuntu-latest
+    - target: linux_arm64
+      file: kubescape-arm64-ubuntu-latest.tar.gz
+      bin: kubescape-arm64-ubuntu-latest
+    - target: win_x64
+      file: kubescape-arm64-windows-latest.tar.gz
+      bin:  kubescape-arm64-windows-latest.exe
+
+bin:
+  kubescape: "{{source.asset.bin}}"


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Adds [kubescape](https://github.com/kubescape/kubescape) (linter & runtime scanner)

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
