### PR TITLE
feat: add zuban lsp

### DIFF
--- a/packages/zuban/package.yaml
+++ b/packages/zuban/package.yaml
@@ -1,7 +1,7 @@
 ---
 name: zuban
-description: Zuban is a high-performance LSP and type checker implemented in Rust, by the author of Jedi.
-homepage: https://zubanls.com/
+description: Zuban is a high-performant Mypy-compatible LSP and type checker built in Rust.
+homepage: https://zubanls.com
 licenses:
   - AGPL-3.0
 languages:

--- a/packages/zuban/package.yaml
+++ b/packages/zuban/package.yaml
@@ -1,0 +1,18 @@
+---
+name: zuban
+description: Zuban is a high-performance LSP and type checker implemented in Rust, by the author of Jedi.
+homepage: https://zubanls.com/
+licenses:
+  - AGPL-3.0
+languages:
+  - Python
+categories:
+  - Linter
+  - LSP
+
+source:
+  id: pkg:pypi/zuban@0.0.24
+
+bin:
+  zuban: pypi:zuban
+


### PR DESCRIPTION
### Describe your changes
Introduce Zuban - a high performant LSP and type checker for Python built in Rust by [David Halter](https://github.com/davidhalter).

### Issue ticket number and link
#11731

### Evidence on requirement fulfillment (new packages only)
1. Approved at [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#zuban).
2. Has [377 stars](https://github.com/zubanls/zuban/stargazers) on Github.

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
<img width="978" height="702" alt="Screenshot 2025-10-01 at 20 02 04" src="https://github.com/user-attachments/assets/a4327816-7795-4661-8f39-ab5a9ebe9133" />

