### PR TITLE
fix(qmlls): update release URL from 0.2 --> 0.4

### DIFF
--- a/packages/qmlls/package.yaml
+++ b/packages/qmlls/package.yaml
@@ -12,7 +12,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/TheQtCompanyRnD/qmlls-workflow@0.2
+  id: pkg:github/TheQtCompanyRnD/qmlls-workflow@0.4
   asset:
     - target: [darwin_x64, darwin_arm64]
       file: qmlls-macos-{{version}}.zip


### PR DESCRIPTION
### Describe your changes
The previous download link for `qmlls` pointed to version **0.2**, which has been removed upstream.
Updated the registry entry to use **0.4** instead.

Release changelog is the same as 0.2 --> 0.4:
https://github.com/TheQtCompanyRnD/qmlls-workflow/releases/

```
Displaying full log                                                                                                     
Downloading file "https://github.com/theqtcompanyrnd/qmlls-workflow/releases/download/0.2/qmlls-ubuntu-0.2.zip"…        
spawn: wget failed with exit code 8 and signal 0.                                                                       
Failed to download file "https://github.com/theqtcompanyrnd/qmlls-workflow/releases/download/0.2/qmlls-ubuntu-0.2.zip". 
```
### Issue ticket number and link
#11747

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
