### PR TITLE
feat: add sqruff lspconfig for nvim

### DIFF
--- a/packages/sqruff/package.yaml
+++ b/packages/sqruff/package.yaml
@@ -32,3 +32,6 @@ source:
 
 bin:
   sqruff: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: sqruff


### PR DESCRIPTION


### Describe your changes

sqruff has a lspconfig available for nvim since https://github.com/neovim/nvim-lspconfig/pull/3723

this is needed in order for mason-lspconfig to autoinstall and enable sqruff, prior to this sqruff had to be configured using null-ls

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

Installed using a copy of the registry and works with mason-lspconfig works as expected
