### PR TITLE
Add neovim.lspconfig value to zuban package

### DIFF
--- a/packages/zuban/package.yaml
+++ b/packages/zuban/package.yaml
@@ -16,3 +16,5 @@ source:
 bin:
   zuban: pypi:zuban
 
+neovim:
+  lspconfig: zuban


### PR DESCRIPTION
### Describe your changes

I added the `neovim.lspconfig` value for the `zuban` package, as it is available in `nvim-lspconfig`.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
