### PR TITLE
RsHtml Language Server Registry

### DIFF
--- a/packages/rshtml-analyzer/package.yaml
+++ b/packages/rshtml-analyzer/package.yaml
@@ -12,7 +12,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/rshtml/rshtml-analyzer@v0.1.4
+  id: pkg:github/rshtml/rshtml-analyzer@v0.1.5
   asset:
     # Linux
     - target: linux_x64_gnu
@@ -41,6 +41,3 @@ source:
 
 bin:
   rshtml-analyzer: "{{source.asset.bin}}"
-
-neovim:
-  lspconfig: rshtml_analyzer


### PR DESCRIPTION
### Describe your changes
Adds a new package definition for `rshtml-analyzer`.

`rshtml-analyzer` is an official language server for the `RsHtml` templating language, which elegantly combines Rust and HTML for use in `.rs.html` files. The package is installed via pre-compiled binaries from GitHub Releases.

### Issue ticket number and link
N/A

### Evidence on requirement fulfillment (new packages only)
This package definition is being submitted by the primary maintainer of the `RsHtml` language and the `rshtml-analyzer` Language Server.

Project repository: https://github.com/rshtml/rshtml
Language server repository: https://github.com/rshtml/rshtml-analyzer

### Checklist before requesting a review
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
N/A