### PR TITLE
feat: add missing lspconfig for django-template-lsp

### DIFF
--- a/packages/django-template-lsp/package.yaml
+++ b/packages/django-template-lsp/package.yaml
@@ -16,3 +16,6 @@ source:
 
 bin:
   djlsp: pypi:django-template-lsp
+
+neovim:
+  lspconfig: djlsp


### PR DESCRIPTION
### Describe your changes
Added missing _neovim.lspconfig_ for django-template-lsp
for `mason-org/mason-lspconfig.nvim` _ensure_installed_ to work for it. 

The djlsp server configuration was added to nvim-lspconfig in PR neovim/nvim-lspconfig#3203


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
