### PR TITLE
feat: add postgres-language-server

### DIFF
--- a/packages/postgres-language-server/package.yaml
+++ b/packages/postgres-language-server/package.yaml
@@ -1,0 +1,36 @@
+---
+name: postgres-language-server
+description: A collection of language tools and a Language Server Protocol (LSP) implementation for Postgres, focusing on developer experience and reliable SQL tooling.
+homepage: https://pg-language-server.com
+licenses:
+  - MIT
+languages:
+  - Postgres
+  - SQL
+categories:
+  - LSP
+  - Linter
+
+source:
+  id: pkg:github/supabase-community/postgres-language-server@0.17.1
+  asset:
+    - target: darwin_arm64
+      file: postgres-language-server_aarch64-apple-darwin
+    - target: darwin_x64
+      file: postgres-language-server_x86_64-apple-darwin
+    - target: linux_x64_gnu
+      file: postgres-language-server_x86_64-unknown-linux-gnu
+    - target: linux_x64_musl
+      file: postgres-language-server_x86_64-unknown-linux-musl
+    - target: linux_arm64_gnu
+      file: postgres-language-server_aarch64-unknown-linux-gnu
+    - target: win_x64
+      file: postgres-language-server_x86_64-pc-windows-msvc
+    - target: win_arm64
+      file: postgres-language-server_aarch64-pc-windows-msvc
+
+bin:
+  postgres-language-server: "{{source.asset.file}}"
+
+neovim:
+  lspconfig: postgres_lsp


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

Adding `postgres-language-server`.

The project itself is already in the registry as `postgrestools`, but we are phasing out the old name due to naming and license issues. We are dual-publishing for a while, so no hurry.

I could not find any infos on how to handle such cases. Adding the new name as a new package and then deleting the old one once its phased out seemed to be the easiest way forward, but happy to do it differently.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

https://github.com/supabase-community/postgres-language-server

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
