### PR TITLE
chore: deprecate postgrestools

### DIFF
--- a/packages/postgrestools/package.yaml
+++ b/packages/postgrestools/package.yaml
@@ -1,5 +1,8 @@
 ---
 name: postgrestools
+deprecation:
+  message: postgrestools has been renamed to postgres-language-server. Please install the new package instead.
+  since: 17.0.0
 description: A collection of language tools and a Language Server Protocol (LSP) implementation for Postgres, focusing on developer experience and reliable SQL tooling.
 homepage: https://pgtools.dev
 licenses:


### PR DESCRIPTION
### Describe your changes
this is the follow up for #12094

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
