### PR TITLE
feat(roc_language_server): Add the Roc Language Server

### DIFF
--- a/packages/roc_language_server/package.yaml
+++ b/packages/roc_language_server/package.yaml
@@ -1,0 +1,28 @@
+name: roc_language_server
+description: This is a basic language server for Roc.
+homepage: https://github.com/roc-lang/roc/tree/main/crates/language_server#roc_language_server
+licenses: ["UPL-1.0"]
+languages: ["Roc"]
+categories: ["LSP"]
+
+source:
+  id: pkg:github/roc-lang/roc@alpha4-rolling
+  asset:
+    - target: linux_arm64
+      file: roc-linux_arm64-{{version}}.tar.gz
+      bin: roc_nightly-linux_arm64-2025-09-09-d73ea10/roc_language_server
+    - target: linux_x64
+      file: roc-linux_x86_64-{{version}}.tar.gz
+      bin: roc_nightly-linux_x86_64-2025-09-09-d73ea109/roc_language_server
+    - target: darwin_arm64
+      file: roc-macos_apple_silicon-{{version}}.tar.gz
+      bin: roc_nightly-macos_apple_silicon-2025-09-09-d73ea109cc2/roc_language_server
+    - target: darwin_x64
+      file: roc-macos_x86_64-{{version}}.tar.gz
+      bin: roc_nightly-macos_x86_64-2025-09-09-d73ea109/roc_language_server
+
+bin:
+  roc_language_server: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: roc_ls


### PR DESCRIPTION
### Describe your changes
Adds the offical Roc LSP

Will require manual maintenance in case of new release due to the packaged directory name. 

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`. ([Already exists](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#roc_ls))
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
<img width="748" height="269" alt="image" src="https://github.com/user-attachments/assets/dbdae004-bd8c-489c-9c4a-2fe01fde95ae" />

