### PR TITLE
docs: improve phrasing for inclusion requirements

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,6 +52,9 @@ At least one of the following conditions MUST be fulfilled for new packages to b
 1. Be approved at [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig).
 1. The tool is officially recommended by a reputable consortium, foundation, or company.
 
+Even if one, or all, of the previous conditions are fulfilled, new package additions may be rejected for other 
+reasons.
+
 # Introduction
 
 * Make sure to follow the [naming guidelines](#name).


### PR DESCRIPTION
### Problem
Our inclusion criteria are meant to be only fulfilled by packages that have evidence of active usage. However, with the current phrasing of the last criterion, a tool that is created by the solo-creator of a language, but where the language itself has little usage, technically fulfills the criterion.

See #11962 

### Suggested Solution
Change the phrasing from "recommended by credible authority like the language maintainer" to "recommended by reputable consortium, foundation, or company". That way packages for niche languages do not fulfill the requirements, but packages like for example `pkl_lsp` by Apple, which at the time of the PR (#8209) did not fulfill the other requirements yet, pass the inclusion criterion.

I think this phrasing better matches the *intention* of the requirements to not include niche tools for security reasons, since tools by companies like Apple or foundations like the Mozilla Foundation are much less unlikely to pose a security problem.