### PR TITLE
bump(api-linter): update to v2.0.0

### DIFF
--- a/packages/api-linter/package.yaml
+++ b/packages/api-linter/package.yaml
@@ -10,7 +10,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:golang/github.com/googleapis/api-linter@v1.72.0#cmd/api-linter
+  id: pkg:golang/github.com/googleapis/api-linter/v2@v2.0.0#cmd/api-linter
 
 bin:
   api-linter: golang:api-linter


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

This bumps the already existing api-linter to v2.0.0.
Supersedes https://github.com/mason-org/mason-registry/pull/12025

Looks good from the logs:

```sh
Installing go package github.com/googleapis/api-linter/v2/cmd/api-linter@v2.0.0…
go: downloading github.com/googleapis/api-linter/v2 v2.0.0
go: downloading github.com/bufbuild/protocompile v0.14.1
go: downloading github.com/olekukonko/tablewriter v0.0.5
go: downloading github.com/spf13/pflag v1.0.7
go: downloading google.golang.org/protobuf v1.36.7
go: downloading gopkg.in/yaml.v3 v3.0.1
go: downloading golang.org/x/sync v0.16.0
go: downloading github.com/bmatcuk/doublestar/v4 v4.9.1
go: downloading github.com/mattn/go-runewidth v0.0.9
go: downloading bitbucket.org/creachadair/stringset v0.0.12
go: downloading github.com/stoewer/go-strcase v1.3.1
go: downloading google.golang.org/genproto/googleapis/api v0.0.0-20250811230008-5f3141c8851a
go: downloading github.com/gertd/go-pluralize v0.2.1
go: downloading golang.org/x/text v0.28.0
go: downloading google.golang.org/genproto v0.0.0-20250811230008-5f3141c8851a
go: downloading cloud.google.com/go/longrunning v0.6.7
go: downloading google.golang.org/grpc v1.74.2
go: downloading google.golang.org/genproto/googleapis/rpc v0.0.0-20250804133106-a7a43d27e69b
go: downloading golang.org/x/sys v0.34.0
go: downloading golang.org/x/net v0.42.0
```

### Issue ticket number and link
<!-- Leave empty if not available -->

N/A

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

N/A

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->

N/A
