### PR TITLE
chore(java-test): bump 0.43.2

### DIFF
--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -21,10 +21,10 @@ categories:
   - DAP
 
 source:
-  id: pkg:openvsx/vscjava/vscode-java-test@0.43.1
+  id: pkg:openvsx/vscjava/vscode-java-test@0.43.2
   download:
     file: vscjava.vscode-java-test-{{version}}.vsix
 
 share:
   java-test/: extension/server/
-  java-test/com.microsoft.java.test.plugin.jar: extension/server/com.microsoft.java.test.plugin-{{version}}.jar
+  java-test/com.microsoft.java.test.plugin.jar: extension/server/com.microsoft.java.test.plugin-0.43.1.jar


### PR DESCRIPTION
### Describe your changes
Java test is down with latest eclipse.jdtls lsp. so upgrading to the latest version fixes test discovering issue :
https://github.com/microsoft/vscode-java-test/releases/tag/0.43.2 : 
https://github.com/microsoft/vscode-java-test/pull/1783

The previous version (0.43.1) is hard coded on purpose, the release 0.43.2 packs the previous jar.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
