### PR TITLE
fix(helm-ls): arm binary is not arm64 anymore

### DIFF
--- a/packages/helm-ls/package.yaml
+++ b/packages/helm-ls/package.yaml
@@ -18,7 +18,7 @@ source:
       file: helm_ls_darwin_arm64
     - target: linux_x64_gnu
       file: helm_ls_linux_amd64
-    - target: linux_arm64
+    - target: linux_arm
       file: helm_ls_linux_arm
     - target: linux_arm64
       file: helm_ls_linux_arm64


### PR DESCRIPTION
### Describe your changes

PR #8086 changed the arm64 target of the helm-ls package to the binary named `helm_ls_linux_arm` since at that time it was a 64 bit build.

However the helm-ls project later fixed [the name in this PR](https://github.com/mrjosh/helm-ls/pull/124). Now there is a `helm_ls_linux_arm_64` for 64 bit clients and `helm_ls_linux_arm` is now a 32 bit build.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots

On an arm64 machine:

#### before

<img width="538" height="114" alt="image" src="https://github.com/user-attachments/assets/0a463d6c-3f34-4448-8d4d-190f5f7e3054" />

<img width="427" height="42" alt="image" src="https://github.com/user-attachments/assets/01aa0085-55eb-48cc-a143-38e482664862" />

<img width="318" height="78" alt="image" src="https://github.com/user-attachments/assets/f41c9473-8d0f-4ce0-b99f-cbf105817500" />

#### after

<img width="471" height="230" alt="image" src="https://github.com/user-attachments/assets/e15402b3-9e80-42e4-99dd-a2dc4cda28da" />

<img width="471" height="320" alt="image" src="https://github.com/user-attachments/assets/7f341f69-73a2-4b41-8266-65430d0fd2b6" />

