### PR TITLE
fix(rumdl): add top level `bin` entry for rumdl executable

### DIFF
--- a/packages/rumdl/package.yaml
+++ b/packages/rumdl/package.yaml
@@ -35,3 +35,6 @@ source:
     - target: win_x64
       file: rumdl-v0.0.164-x86_64-pc-windows-msvc.zip
       bin: rumdl.exe
+
+bin:
+  rumdl: "{{source.asset.bin}}"


### PR DESCRIPTION
Ensure rumdl is symlinked into mason/bin by adding top level `bin` entry

- [/] I have successfully tested installation of the package.
- [/] I have successfully tested the package after installation.