### PR TITLE
feat(mesonlsp): Add linux aarch64 support

### DIFF
--- a/packages/mesonlsp/package.yaml
+++ b/packages/mesonlsp/package.yaml
@@ -15,6 +15,9 @@ source:
     - target: linux_x64
       file: mesonlsp-x86_64-unknown-linux-musl.zip
       bin: mesonlsp
+    - target: linux_arm64
+      file: mesonlsp-aarch64-unknown-linux-musl.zip
+      bin: mesonlsp
     - target: darwin_x64
       file: mesonlsp-x86_64-apple-darwin.zip
       bin: mesonlsp


### PR DESCRIPTION
### Describe your changes
Add support for linux arm

### Checklist before requesting a review
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
Successfully started the mesonlsp server inside nvim. Text document hover, diagnostics, and completions working normally.
Tested on Arch Linux ARM, Linux 6.17.0-PRoot-Distro aarch64