### PR TITLE
fix(haskell-debug-adapter): migrate to cabal

### DIFF
--- a/packages/haskell-debug-adapter/package.yaml
+++ b/packages/haskell-debug-adapter/package.yaml
@@ -15,7 +15,7 @@ source:
   build:
     - target: unix
       run: |
-        cabal install haskell-dap ghci-dap haskell-debug-adapter-"$VERSION" --install-method=copy --installdir="$PWD"
+        cabal update && cabal install haskell-dap ghci-dap haskell-debug-adapter-"$VERSION" --install-method=copy --installdir="$PWD"
       staged: false
       env:
         VERSION: "{{version}}"
@@ -25,7 +25,7 @@ source:
 
     - target: win
       run: |
-        cabal install haskell-dap ghci-dap haskell-debug-adapter-$env:VERSION --install-method=copy --installdir="$pwd"
+        cabal update && cabal install haskell-dap ghci-dap haskell-debug-adapter-$env:VERSION --install-method=copy --installdir="$pwd"
       staged: false
       env:
         VERSION: "{{version}}"


### PR DESCRIPTION
Mason currently installs HLS using Cabal and `haskell-debug-adapter` using Stack. Using a single package manager simplifies the setup and avoids fragmentation.

This inconsistency has already caused confusion (see [#1571](https://github.com/williamboman/mason.nvim/issues/1571)).

Closes: https://github.com/mason-org/mason.nvim/issues/1913

### Describe your changes
Changed the Stack command to the equivalent Cabal one

### Issue ticket number and link
https://github.com/mason-org/mason.nvim/issues/1913

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.