### PR TITLE
feat(cue): Add the official updated cue LSP

### DIFF
--- a/packages/cuepls/package.yaml
+++ b/packages/cuepls/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 deprecation:
-  message: cuepls has now been renamed to cue. Please install the new package instead.
+  message: The CUE language server is now included in the cue language binary.
   since: v0.11.1
 
 source:


### PR DESCRIPTION
### Describe your changes
Since the cue lsp has been updated to v0.15.0 with a lot of new functionalities, I want to update the mason registry to reflect the new changes.
I named this "cue" because that's the name of the lsp in nvim-lspconfig, although the name of the cue lsp seems to be "cuelsp" now, but that conflicts with the existing dagger cue lsp which is archived on January 2025 (https://github.com/dagger/cuelsp)
The three options that I see are to add the new cue lsp as "cue", replace cuepls with the new version and undeprecate it, or to replace the dagger lsp with the offical cue lsp. For now I'm choosing the first option but I am fine with any of them.

### Issue ticket number and link
N/A

### Evidence on requirement fulfillment (new packages only)
1. https://github.com/cue-lang/cue: 5.8k stars
2. https://marketplace.visualstudio.com/items?itemName=cuelangorg.vscode-cue: 2729 installs (hopefully it's fine since cuepls already exists in this repo).
3. https://github.com/neovim/nvim-lspconfig/blob/master/lsp/cue.lua.
4. This is the official cue LSP.

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
<img width="2555" height="873" alt="image" src="https://github.com/user-attachments/assets/d6734f8b-4a5d-47ce-860c-3b837e07598f" />
<img width="339" height="215" alt="image" src="https://github.com/user-attachments/assets/dc473cb5-bd07-4f32-a042-d639ffd9d0a7" />