### PR TITLE
Add rdbg: Ruby Debug Adapter Protocol implementation (debug gem v1.11.0)

### DIFF
--- a/packages/rdbg/package.yaml
+++ b/packages/rdbg/package.yaml
@@ -1,0 +1,16 @@
+---
+name: rdbg
+description: Debug Adapter Protocol implementation for Ruby, powered by rdbg.
+homepage: https://github.com/ruby/debug
+licenses:
+  - BSD-2-Clause
+languages:
+  - Ruby
+categories:
+  - DAP
+
+source:
+  id: pkg:gem/debug@1.11.0
+
+bin:
+  rdbg: gem:rdbg


### PR DESCRIPTION
### Describe your changes
Added a new package: rdbg (Ruby Debug Adapter). This package provides integration for Ruby debugging in supported editors. The package files and installation scripts were added according to the repository guidelines.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
- [Ruby Debug Adapter GitHub repository](https://github.com/ruby/debug)
- [Official documentation](https://github.com/ruby/debug#readme)

### Checklist before requesting a review
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<img width="1148" height="873" alt="Screenshot 2025-11-16 at 18 45 00" src="https://github.com/user-attachments/assets/a6ab3726-346b-4d49-b7b8-bc8a0d403c25" />
