### PR TITLE
feat: add tclint LSP, linter and formatter

### DIFF
--- a/packages/tclint/package.yaml
+++ b/packages/tclint/package.yaml
@@ -1,0 +1,23 @@
+---
+name: tclint
+description: Modern dev tools for Tcl • includes a linter, formatter, and editor integration.
+homepage: https://github.com/nmoroze/tclint
+licenses:
+  - MIT
+languages:
+  - Tcl
+categories:
+  - Linter
+  - Formatter
+  - LSP
+
+source:
+  id: pkg:pypi/tclint@0.6.1
+
+bin:
+  tclint: pypi:tclint
+  tclfmt: pypi:tclfmt
+  tclsp: pypi:tclsp
+
+neovim:
+  lspconfig: tclsp


### PR DESCRIPTION
### Describe your changes
Add support for [tclint](https://github.com/nmoroze/tclint/tree/main) LSP, linter and formatter

### Evidence on requirement fulfillment (new packages only)
* PR for nvim-lspconfig merged at https://github.com/neovim/nvim-lspconfig/pull/4200
* Almost a 100 stars at https://github.com/nmoroze/tclint/
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->
