### PR TITLE
fix(basics-language-server): add lspconfig name

### DIFF
--- a/packages/basics-language-server/package.yaml
+++ b/packages/basics-language-server/package.yaml
@@ -16,3 +16,6 @@ schemas:
 
 bin:
   basics-language-server: npm:basics-language-server
+
+neovim:
+  lspconfig: basics_ls


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Added lspconfig name [`basics_ls`](https://github.com/neovim/nvim-lspconfig/blob/5a49a97f9d3de5c39a2b18d583035285b3640cb0/lsp/basics_ls.lua)

### Issue ticket number and link
<!-- Leave empty if not available -->
#7570

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
