### PR TITLE
bump(cypher_ls): update to 0.0.0-canary-20250423075344

### DIFF
--- a/packages/cypher-language-server/package.yaml
+++ b/packages/cypher-language-server/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:npm/%40neo4j-cypher/language-server@2.0.0-next.26
+  id: pkg:npm/%40neo4j-cypher/language-server@0.0.0-canary-20250423075344
 
 bin:
   cypher-language-server: npm:cypher-language-server


### PR DESCRIPTION
Current version of 2.0.0-next.26 is broken due to:
```
[ERROR][2025-11-14 19:47:04] ...p/_transport.lua:36	"rpc"	"cypher-language-server"	"stderr"	"Error: Cannot find module '~/.local/share/nvim/mason/packages/cypher-language-server/node_modules/@neo4j-cypher/language-server/dist/lintWorker.cjs'\n    at Function._resolveFilename (node:internal/modules/cjs/loader:1383:15)\n    at defaultResolveImpl (node:internal/modules/cjs/loader:1025:19)\n    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1030:22)\n    at Function._load (node:internal/modules/cjs/loader:1192:37)\n    at TracingChannel.traceSync (node:diagnostics_channel:328:14)\n    at wrapModuleLoad (node:internal/modules/cjs/loader:237:24)\n    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:171:5)\n    at MessagePort.<anonymous> (node:internal/main/worker_thread:226:26)\n    at [nodejs.internal.kHybridDispatch] (node:internal/event_target:845:20)\n    at MessagePort.<anonymous> (node:internal/per_context/messageport:23:28) {\n  code: 'MODULE_NOT_FOUND',\n  requireStack: []\n}\n"
```

### Describe your changes
Bump to the version of cypher_ls

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->
