### PR TITLE
fix: nvim-lspconfig renamed cds-lsp + added neovim.lspconfig

### DIFF
--- a/packages/cds-lsp/package.yaml
+++ b/packages/cds-lsp/package.yaml
@@ -1,5 +1,5 @@
 ---
-name: cds_lsp
+name: cds-lsp
 description: Language server for CDS
 homepage: https://cap.cloud.sap
 licenses:


### PR DESCRIPTION
### Describe your changes

- `nvim-lspconfig` renamed `cds-lsp` to `cds_lsp`
- `mason-registry` is now following that name change
  - package folder renamed
  - `package.yaml` adjusted
- Added `neovim.lspconfig` to `package.yaml`


### Issue ticket number and link

#12537 

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.


### Screenshots

`:checkhealth vim.lsp` :

<img width="927" height="674" alt="image" src="https://github.com/user-attachments/assets/e0aff7a9-1229-4778-a8a1-6dd8e093f1f5" />

