### PR TITLE
feat(hyprls)!: download directly from GitHub

### DIFF
--- a/packages/hyprls/package.yaml
+++ b/packages/hyprls/package.yaml
@@ -10,10 +10,20 @@ categories:
   - LSP
 
 source:
-  id: pkg:golang/github.com/hyprland-community/hyprls@v0.11.0#cmd/hyprls
+  id: pkg:github/hyprland-community/hyprls@v0.11.0
+  asset:
+    - target: darwin_arm64
+      file: hyprls-macos
+      bin: hyprls-macos
+    - target: win_x64
+      file: hyprls.exe
+      bin: hyprls.exe
+    - target: linux_x64_gnu
+      file: hyprls
+      bin: hyprls
 
 bin:
-  hyprls: golang:hyprls
+  hyprls: "{{source.asset.bin}}"
 
 neovim:
   lspconfig: hyprls


### PR DESCRIPTION
### Describe your changes
Instead of building `hyprls` from source, we can just fetch the [binaries](https://github.com/hyprland-community/hyprls/releases). Not sure when those were introduced (surely after it was added to the registry). This simplifies installation for folks like me, who otherwise wouldn't use `golang`.

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

