### PR TITLE
fix(postgrestools): removed invalid lspconfig

### DIFF
--- a/packages/postgrestools/package.yaml
+++ b/packages/postgrestools/package.yaml
@@ -32,6 +32,3 @@ source:
 
 bin:
   postgrestools: "{{source.asset.file}}"
-
-neovim:
-  lspconfig: postgres_lsp


### PR DESCRIPTION
### Describe your changes
Updates to the `postgres_lsp` configuration in `neovim/nvim-lspconfig` now point to `postgres-language-server`, and `vim.lsp.enable('posgres_lsp')` no longer works with the `postgrestools` package.

https://github.com/neovim/nvim-lspconfig/pull/4155

Additionally, since both the `postgrestools` and `postgres-language-server` contain the same lspconfig, there is an issue with `mason-lspconfig`'s `ensure_installed`.

I don't know the easiest way to show this but the gist of it is `ensure_installed` gets the list of packages from `mason-lspconfig.mappings.get_mason_map()`, which uses `mason-core.functional.invert` to get the lspconfig -> package conversions. Since the `invert` function doesn't expect the duplication, `ensure_installed` installs whichever package happened to be farther down in the local registry. Within a few restarts of neovim you'll have both `postgrestools` and `postgres-language-server` installed. If between editing your config and opening a file `mason-lspconfig` only installed the deprecated `postgrestools` you won't have any active LSPs.

I successfully tested the updated package.yaml with
```
vim.lsp.config('postgres_lsp', { cmd = { "postgrestools", "lsp-proxy" } } )
```

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
