### PR TITLE
fix(ast-grep): switch to PyPI version of the package

### DIFF
--- a/packages/ast-grep/package.yaml
+++ b/packages/ast-grep/package.yaml
@@ -28,11 +28,11 @@ categories:
   - LSP
 
 source:
-  id: pkg:npm/%40ast-grep/cli@0.40.0
+  id: pkg:pypi/ast-grep-cli@0.40.0
 
 bin:
-  ast-grep: npm:ast-grep
-  sg: npm:sg
+  ast-grep: pypi:ast-grep
+  sg: pypi:sg
 
 neovim:
   lspconfig: ast_grep


### PR DESCRIPTION
### Describe your changes

Due to recent Shai-Hulud 2.0 attack on NPM repositories, many places recommend or mandate disabling install scripts. The NPM version of `ast-grep` package uses the postinstall step as a workaround for selecting correct libraries for the system, which does not happen with scripts disabled, resulting in a dummy being left instead. The solution is to switch to version from PyPI, which has no such problems.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [X] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
