### PR TITLE
fix(ast-grep): download directly as GitHub asset

### DIFF
--- a/packages/ast-grep/package.yaml
+++ b/packages/ast-grep/package.yaml
@@ -28,11 +28,29 @@ categories:
   - LSP
 
 source:
-  id: pkg:npm/%40ast-grep/cli@0.40.0
+  id: pkg:github/ast-grep/ast-grep@0.40.0
+  asset:
+    - target: darwin_arm64
+      file: app-aarch64-apple-darwin.zip
+    - target: darwin_x64
+      file: app-x86_64-apple-darwin.zip
+    - target: linux_arm64_gnu
+      file: app-aarch64-unknown-linux-gnu.zip
+    - target: linux_x64_gnu
+      file: app-x86_64-unknown-linux-gnu.zip
+    - target: win_arm64
+      file: app-aarch64-pc-windows-msvc.zip
+      ext: .exe
+    - target: win_x64
+      file: app-x86_64-pc-windows-msvc.zip
+      ext: .exe
+    - target: win_x86
+      file: app-i686-pc-windows-msvc.zip
+      ext: .exe
 
 bin:
-  ast-grep: npm:ast-grep
-  sg: npm:sg
+  ast-grep: ast-grep{{source.asset.ext}}
+  sg: sg{{source.asset.ext}}
 
 neovim:
   lspconfig: ast_grep


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

Due to recent Shai-Hulud 2.0 attack on NPM repositories, many places recommend or mandate disabling install scripts. The NPM version of `ast-grep` package uses the postinstall step as a workaround for selecting correct libraries for the system, which does not happen with scripts disabled, resulting in a dummy being left instead. Downloading it directly from GitHub avoids the issue.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [X] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
