### PR TITLE
feat: add dingo and dingo-lsp packages

### DIFF
--- a/packages/dingo-lsp/package.yaml
+++ b/packages/dingo-lsp/package.yaml
@@ -1,0 +1,19 @@
+---
+name: dingo-lsp
+description: |
+  Language Server Protocol implementation for Dingo. Wraps gopls and translates positions between .dingo
+  and .go files using source maps, providing full IDE support including go-to-definition, hover, completion,
+  diagnostics, and rename refactoring.
+homepage: https://github.com/MadAppGang/dingo
+licenses:
+  - MIT
+languages:
+  - Dingo
+categories:
+  - LSP
+
+source:
+  id: pkg:golang/github.com/MadAppGang/dingo/cmd/dingo-lsp@v0.5.0
+
+bin:
+  dingo-lsp: golang:dingo-lsp

--- a/packages/dingo/package.yaml
+++ b/packages/dingo/package.yaml
@@ -1,0 +1,22 @@
+---
+name: dingo
+description: |
+  Dingo is a meta-language for Go that adds enhanced type safety and modern syntax (enums, pattern matching,
+  error propagation, lambdas) while transpiling to idiomatic Go code. The CLI provides build, run, format,
+  and lint commands.
+homepage: https://github.com/MadAppGang/dingo
+licenses:
+  - MIT
+languages:
+  - Dingo
+  - Go
+categories:
+  - Compiler
+  - Formatter
+  - Linter
+
+source:
+  id: pkg:golang/github.com/MadAppGang/dingo/cmd/dingo@v0.5.0
+
+bin:
+  dingo: golang:dingo


### PR DESCRIPTION
## Summary

Add [Dingo](https://github.com/MadAppGang/dingo) language tools to the mason registry:

- **dingo**: CLI for building, running, formatting (`dingo fmt`), and linting (`dingo lint`) Dingo code
- **dingo-lsp**: Language Server Protocol implementation that wraps `gopls` with source map translation

## About Dingo

Dingo is a meta-language for Go that adds enhanced type safety and modern syntax while transpiling to idiomatic Go code:

- `enum` declarations with associated values (sum types)
- `match` expressions with exhaustive pattern matching
- Error propagation (`?` operator)
- Safe navigation (`?.`) and null coalescing (`??`)
- Lambda expressions (`|x| expr` and `x => expr`)
- Tuple destructuring

## Repository Stats

- **Stars**: 1000+
- **Repository**: https://github.com/MadAppGang/dingo
- **License**: MIT

## Installation Test

```bash
go install github.com/MadAppGang/dingo/cmd/dingo@v0.5.0
go install github.com/MadAppGang/dingo/cmd/dingo-lsp@v0.5.0
```

## Neovim Integration

A companion Neovim plugin is available at https://github.com/MadAppGang/dingo.nvim with:
- LSP integration via `dingo-lsp`
- Tree-sitter syntax highlighting
- Format on save
- Lint integration