### PR TITLE
Specify kotlin-lsp version format for Renovate

### DIFF
--- a/packages/kotlin-lsp/package.yaml
+++ b/packages/kotlin-lsp/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  # renovate:versioning=loose
+  # renovate:versioning=regex:^kotlin-lsp/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
   # renovate:datasource=github-releases
   id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v0.253.10629
   download:


### PR DESCRIPTION
### Describe your changes
Modifies the `renovate` configuration for [kotlin-lsp](https://github.com/Kotlin/kotlin-lsp/releases) releases. The `loose` format does not correctly identify `kotlin-lsp/v<major>.<minor>.<patch>` versions.

Verified this by running `renovate` locally with debug mode on:
```
           {
             "deps": [
               {
                 "depName": "kotlin-lsp",
                 "packageName": "Kotlin/kotlin-lsp",
                 "currentValue": "kotlin-lsp/v0.253.10629",
                 "datasource": "github-releases",
                 "versioning": "regex:^kotlin-lsp/v(?<major>\\d+)\\.(?<minor>\\d+)\\.(?<patch>\\d+)$",
                 "replaceString": "\n  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v0.253.10629",
                 "updates": [
                   {
                     "bucket": "latest",
                     "newVersion": "kotlin-lsp/v261.13587.0",
                     "newValue": "kotlin-lsp/v261.13587.0",
                     "releaseTimestamp": "2025-12-10T12:38:08.000Z",
                     "newMajor": 261,
                     "newMinor": 13587,
                     "newPatch": 0,
                     "updateType": "major",
                     "branchName": "renovate/kotlin-lsp-261.x"
                   }
                 ],
                 "warnings": [],
                 "sourceUrl": "https://github.com/Kotlin/kotlin-lsp",
                 "registryUrl": "https://github.com",
                 "currentVersion": "kotlin-lsp/v0.253.10629",
                 "currentVersionTimestamp": "2025-08-06T13:33:06.000Z",
                 "isSingleVersion": true,
                 "fixedVersion": "kotlin-lsp/v0.253.10629"
               }
             ],
             "matchStrings": [
               "\nname: (?<depName>.+)",
               "\n  id:\\s+pkg:generic\\/(?<packageName>.+)@(?<currentValue>[^\\s\\?#]+)",
               "# renovate:.*versioning=(?<versioning>[^,\n]+)",
               "# renovate:.*datasource=(?<datasource>[^,\n]+)"
             ],
             "matchStringsStrategy": "combination",
             "currentValueTemplate": "{{{decodeURIComponent currentValue}}}",
             "datasourceTemplate": "{{{datasource}}}",
             "versioningTemplate": "{{#if versioning}}{{{versioning}}}{{else}}semver{{/if}}",
             "packageFile": "packages/kotlin-lsp/package.yaml"
           },

```

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
