### PR TITLE
bump(kotlin-lsp): update to v261.13587.0

### DIFF
--- a/packages/kotlin-lsp/package.yaml
+++ b/packages/kotlin-lsp/package.yaml
@@ -12,12 +12,32 @@ categories:
 source:
   # renovate:versioning=loose
   # renovate:datasource=github-releases
-  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v0.253.10629
+  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v261.13587.0
   download:
-    - target: unix
+    - target: darwin_x64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-{{ version | strip_prefix "kotlin-lsp/v" }}.zip
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-mac-x64.zip
       bin: kotlin-lsp.sh
+    - target: darwin_arm64
+      files:
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-mac-aarch64.zip
+      bin: kotlin-lsp.sh
+    - target: linux_x64
+      files:
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-linux-x64.zip
+      bin: kotlin-lsp.sh
+    - target: linux_arm64
+      files:
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-linux-aarch64.zip
+      bin: kotlin-lsp.sh
+    - target: win_x64
+      files:
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-win-x64.zip
+      bin: kotlin-lsp.cmd
+    - target: win_arm64
+      files:
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-win-aarch64.zip
+      bin: kotlin-lsp.cmd
 
 bin:
   kotlin-lsp: "{{source.download.bin}}"


### PR DESCRIPTION
### Describe your changes
[New release](https://github.com/Kotlin/kotlin-lsp/releases) of kotlin-lsp is created

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
