### PR TITLE
fix(rumdl): add `neovim.lspconfig`

### DIFF
--- a/packages/rumdl/package.yaml
+++ b/packages/rumdl/package.yaml
@@ -38,3 +38,6 @@ source:
 
 bin:
   rumdl: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: rumdl


### PR DESCRIPTION
### Describe your changes
add `neovim.lspconfig` for `rumdl`, available at lspconfig: https://github.com/neovim/nvim-lspconfig/blob/master/lsp/rumdl.lua


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
