### PR TITLE
feat: add `vscode-home-assistant`

### DIFF
--- a/packages/vscode-home-assistant/package.yaml
+++ b/packages/vscode-home-assistant/package.yaml
@@ -1,0 +1,21 @@
+---
+name: vscode-home-assistant
+description: Language Server Protocol implementation for Home Assistant.
+homepage: https://github.com/keesschollaart81/vscode-home-assistant
+licenses:
+  - MIT
+languages:
+  - YAML
+categories:
+  - LSP
+
+source:
+  id: pkg:openvsx/keesschollaart/vscode-home-assistant@2.2.0
+  download:
+    file: keesschollaart.vscode-home-assistant-{{version}}.vsix
+
+bin:
+  vscode-home-assistant: node:extension/out/server/server.js
+
+neovim:
+  lspconfig: home_assistant


### PR DESCRIPTION
### Describe your changes
This adds the ability to install the Home Assistant Language Server as provided by the popular VS Code extension

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)

- The language server repository has 600+ stars on GitHub: https://github.com/keesschollaart81/vscode-home-assistant
    - Language server has been updated and maintained for 5+ years on GitHub
- The VS Code extension has >22k downloads through OpenVSX (https://open-vsx.org/extension/keesschollaart/vscode-home-assistant)

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`. (https://github.com/neovim/nvim-lspconfig/pull/4248)
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
