### PR TITLE
feat: added systemd-lsp

### DIFF
--- a/packages/systemd-lsp/package.yaml
+++ b/packages/systemd-lsp/package.yaml
@@ -1,0 +1,29 @@
+---
+name: systemd-lsp
+description: a language server implementation for systemd unit files made in rust
+homepage: https://github.com/JFryy/systemd-lsp
+licenses:
+  - MIT
+languages:
+  - systemd
+categories:
+  - LSP
+
+source:
+  # renovate:versioning=loose
+  id: pkg:github/JFryy/systemd-lsp@v2025.10.16
+  asset:
+    - target: darwin_x64
+      file: systemd-lsp-x86_64-apple-darwin
+    - target: darwin_arm64
+      file: systemd-lsp-x86_64-apple-darwin
+    - target: linux_x64_gnu
+      file: systemd-lsp-x86_64-unknown-linux-gnu
+    - target: win_x64
+      file: systemd-lsp-x86_64-pc-windows-msvc.exe
+
+bin:
+  systemd-lsp: "{{source.asset.file}}"
+
+neovim:
+  lspconfig: systemd_lsp


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

Added the [systemd-lsp](https://github.com/JFryy/systemd-lsp) sprung-off of the not-so-maintained [systemd-language-server](https://github.com/neovim/nvim-lspconfig/issues/4134)

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#systemd_lsp

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
