### PR TITLE
fix: json-repair binary is with a underscore

### DIFF
--- a/packages/json-repair/package.yaml
+++ b/packages/json-repair/package.yaml
@@ -13,4 +13,4 @@ source:
   id: pkg:pypi/json-repair@0.54.3
 
 bin:
-  json_repair: pypi:json-repair
+  json_repair: pypi:json_repair


### PR DESCRIPTION
### Describe your changes
Fixes a typo that I made in #12915 :'(

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
