### PR TITLE
feat: added squawk - a postgres SQL migrations linter

### DIFF
--- a/packages/squawk/package.yaml
+++ b/packages/squawk/package.yaml
@@ -1,0 +1,30 @@
+---
+name: squawk
+description: Linter for Postgres migrations & SQL
+homepage: https://github.com/sbdchd/squawk
+licenses:
+  - Apache-2.0
+languages:
+  - Postgres
+  - SQL
+categories:
+  - Linter
+
+source:
+  id: pkg:github/sbdchd/squawk@v2.34.0
+  asset:
+    - target: darwin_x64
+      file: squawk-darwin-x64
+    - target: darwin_arm64
+      file: squawk-darwin-arm64
+    - target: linux_arm64
+      file: squawk-linux-arm64
+    - target: linux_x64_musl
+      file: squawk-linux-musl-x64
+    - target: linux_x64
+      file: squawk-linux-x64
+    - target: win_x64
+      file: squawk-windows-x64.exe
+
+bin:
+  squawk: "{{source.asset.file}}"


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Added [`squawk`](https://github.com/sbdchd/squawk) - a PostgresSQL linter specifically for migrations


### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

Just under 1K stars on [Github](https://github.com/sbdchd/squawk), and can be used with the popular [nvim-lint](https://github.com/mfussenegger/nvim-lint/blob/master/lua/lint/linters/squawk.lua) plugin

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

This time I **really** tested it :--)

### Screenshots
<!-- Leave empty if not applicable -->
