### PR TITLE
feat: add Xcode-build-server

### DIFF
--- a/packages/xcode-build-server/package.yaml
+++ b/packages/xcode-build-server/package.yaml
@@ -8,10 +8,11 @@ languages:
   - Swift
 categories:
   - LSP
-
 source:
   id: pkg:github/SolaWing/xcode-build-server@v1.2.0
   build:
-    target: darwin
+    target: darwin_arm64
     run: |
-      ln -s "$MASON/packages/xcode-build-server/xcode-build-server" "$MASON/bin"
+    bin: xcode-build-server
+bin:
+  xcode-build-server: "{{source.build.bin}}"


### PR DESCRIPTION
### Describe your changes
Adding Xcode-build-server to aide in iOS development

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->
https://github.com/SolaWing/xcode-build-server
Over 100 stars
### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
