### PR TITLE
fix: deprecate systemd-language-server in favor of systemd-lsp

### DIFF
--- a/packages/systemd-language-server/package.yaml
+++ b/packages/systemd-language-server/package.yaml
@@ -1,5 +1,8 @@
 ---
 name: systemd-language-server
+deprecation:
+  message: systemd-language-server is deprecated in favor of systemd-lsp
+  since: 0.3.5
 description: |
   Language Server for Systemd unit files
 homepage: https://github.com/psacawa/systemd-language-server


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

Follow up to: https://github.com/mason-org/mason-registry/pull/12914#pullrequestreview-3613865476

Deprecates the systemd-language-server in favor of systemd-lsp, as systemd-language-server has been deprecated in nvim-lspconfig

### Issue ticket number and link
<!-- Leave empty if not available -->
https://github.com/neovim/nvim-lspconfig/issues/4134 / https://github.com/neovim/nvim-lspconfig/pull/4262

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
<img width="788" height="196" alt="image" src="https://github.com/user-attachments/assets/35258d5a-8b17-468e-9b48-2692c19d2254" />
