### PR TITLE
feat(gh-actions-language-server): use official npm package

### DIFF
--- a/packages/gh-actions-language-server/package.yaml
+++ b/packages/gh-actions-language-server/package.yaml
@@ -1,7 +1,7 @@
 ---
 name: gh-actions-language-server
 description: GitHub Actions Language Server
-homepage: https://github.com/lttb/gh-actions-language-server
+homepage: https://github.com/actions/languageservices
 licenses:
   - MIT
 languages:
@@ -10,10 +10,10 @@ categories:
   - LSP
 
 source:
-  id: pkg:npm/gh-actions-language-server@0.0.3
+  id: pkg:npm/%40actions/languageserver@0.3.31
 
 bin:
-  gh-actions-language-server: npm:gh-actions-language-server
+  gh-actions-language-server: npm:actions-languageserver
 
 neovim:
   lspconfig: gh_actions_ls


### PR DESCRIPTION
### Describe your changes
switch to official GitHub Actions LSP npm as it's now available.

### Issue ticket number and link
resolves #12995 

### Evidence on requirement fulfillment (new packages only)
-

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
