### PR TITLE
chore(grammarly-lsp): add deprecation

### DIFF
--- a/packages/grammarly-languageserver/package.yaml
+++ b/packages/grammarly-languageserver/package.yaml
@@ -2,6 +2,11 @@
 name: grammarly-languageserver
 description: A language server implementation on top of Grammarly's SDK.
 homepage: https://github.com/znck/grammarly
+
+deprecation:
+  since: "0.0.4"
+  message: Repo archived in 2024.
+
 licenses:
   - MIT
 languages:


### PR DESCRIPTION
repo has been archived in 2024. 
https://github.com/znck/grammarly
