### PR TITLE
fix: add supported_platforms back to nixfmt

### DIFF
--- a/packages/nixfmt/package.yaml
+++ b/packages/nixfmt/package.yaml
@@ -14,6 +14,8 @@ source:
   asset:
     - target: linux_x64
       file: nixfmt-x86_64-linux
+  supported_platforms:
+    - linux_x64
 
 bin:
   nixfmt: "{{source.asset.file}}"


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Hey all.
I'm the author of [mason.el](https://github.com/deirn/mason.el), which use the registry to install packages for Emacs.

I have a CI that runs daily for validating my project against all the packages from the registry, which failed to resolve the recipe for nixfmt because it can't get the target file for MacOS.

The CI currently only ignores the error if the recipe's `supported_platform` doesn't contain the current platform:
https://github.com/deirn/mason.el/commit/64f6842da0b4505e2ebfa0e2d980c1f1b1f969ea
https://github.com/deirn/mason.el/actions/runs/20724712516/job/59497294737

Changing it would make the logic more complex as I would've liked, so I think changing it here will be better.

Cheers.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
