### PR TITLE
Add effect-language-service

### DIFF
--- a/packages/effect-language-service/package.yaml
+++ b/packages/effect-language-service/package.yaml
@@ -8,8 +8,7 @@ licenses:
   - MIT
 languages:
   - TypeScript
-categories:
-  - Linter
+categories: []
 
 source:
   id: pkg:npm/@effect/language-service@0.47.0

--- a/packages/effect-language-service/package.yaml
+++ b/packages/effect-language-service/package.yaml
@@ -1,0 +1,18 @@
+---
+name: effect-language-service
+description: |-
+  TypeScript language service plugin that provides additional refactors and diagnostics for Effect-TS projects.
+  Supports code actions, completions, and enhanced type information for Effect code.
+homepage: https://github.com/Effect-TS/language-service
+licenses:
+  - MIT
+languages:
+  - TypeScript
+categories:
+  - LSP
+
+source:
+  id: pkg:npm/@effect/language-service@0.47.0
+
+bin:
+  effect-language-service: npm:effect-language-service

--- a/packages/effect-language-service/package.yaml
+++ b/packages/effect-language-service/package.yaml
@@ -9,7 +9,7 @@ licenses:
 languages:
   - TypeScript
 categories:
-  - LSP
+  - Linter
 
 source:
   id: pkg:npm/@effect/language-service@0.47.0


### PR DESCRIPTION
### Describe your changes
Adds ⁠[effect-language-service](https://github.com/Effect-TS/language-service/), a TypeScript language service plugin that provides enhanced diagnostics, refactors, and code actions for Effect-TS projects.

This package is a TypeScript plugin designed to be loaded with `⁠typescript-language-server`, not a standalone LSP server. While the official documentation recommends per-project installation with npm, this PR enables global installation with Mason and manual configuration in ⁠`vim.lsp.config`. If this doesn't fit mason-registry's scope, I understand.

### Evidence on requirement fulfillment (new packages only)
The [repository](https://github.com/Effect-TS/language-service/) has 316 stars on GitHub at the time of this PR.

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`. 

> **N/A**: This is a TypeScript plugin, not a standalone LSP server

- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
<img width="964" height="387" alt="image" src="https://github.com/user-attachments/assets/1767baae-a0f4-4c2d-9671-80f53ad15243" />
<img width="1454" height="981" alt="image" src="https://github.com/user-attachments/assets/12b92986-011a-4654-bfb2-f402dc61a0c3" />

### Testing details
- Successfully installed via ⁠`:MasonInstall effect-language-service`
- Configured in `⁠vim.lsp.config` with ⁠`init_options.plugins.location` pointing to Mason installation
- Confirmed Effect diagnostics appear (e.g., "Effect must be yielded or assigned to a variable")
- Tested in a project WITHOUT ⁠`@effect/language-service` in ⁠`node_modules` to verify Mason installation works

### Example configuration
```lua
vim.lsp.config("ts_ls", {
  init_options = {
    plugins = {
      {
        name = "@effect/language-service",
        location = vim.fn.stdpath("data") 
          .. "/mason/packages/effect-language-service/node_modules/@effect/language-service",
      },
    },
  },
})
```