### PR TITLE
feat: gn-language-server

### DIFF
--- a/packages/gn-language-server/package.yaml
+++ b/packages/gn-language-server/package.yaml
@@ -1,0 +1,26 @@
+---
+name: gn-language-server
+description: A language server for GN, the build configuration language used in Chromium, Fuchsia, and other projects.
+homepage: https://github.com/google/gn-language-server
+licenses:
+  - Apache-2.0
+languages:
+  - GN
+categories:
+  - LSP
+
+source:
+  id: pkg:github/google/gn-language-server@v1.10.3
+  asset:
+    - target: darwin_arm64
+      file: gn-language-server-{{ version | strip_prefix "v" }}-darwin-aarch64
+    - target: linux_x64
+      file: gn-language-server-{{ version | strip_prefix "v" }}-linux-x86_64
+    - target: win_x64
+      file: gn-language-server-{{ version | strip_prefix "v" }}-windows-x86_64.exe
+
+bin:
+  gn-language-server: "{{source.asset.file}}"
+
+neovim:
+  lspconfig: gn_language_server


### PR DESCRIPTION
### Describe your changes

This patch adds support for [gn-language-server](https://github.com/google/gn-language-server), a language server for GN (the build configuration language used in Chromium, Fuchsia, and other projects).

### Issue ticket number and link

N/A

### Evidence on requirement fulfillment (new packages only)

- Approved in nvim-lspconfig. https://github.com/neovim/nvim-lspconfig/pull/4276

### Checklist before requesting a review

- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots

N/A
