### PR TITLE
feat(wasm-language-tools): add more targets

### DIFF
--- a/packages/wasm-language-tools/package.yaml
+++ b/packages/wasm-language-tools/package.yaml
@@ -20,8 +20,17 @@ source:
     - target: darwin_x64
       file: wat_server-x86_64-macos.zip
       bin: wat_server
-    - target: linux_x64
+    - target: linux_x64_gnu
       file: wat_server-x86_64-linux.zip
+      bin: wat_server
+    - target: linux_x64
+      file: wat_server-x86_64-alpine.zip
+      bin: wat_server
+    - target: linux_arm64_gnu
+      file: wat_server-arm64-linux.zip
+      bin: wat_server
+    - target: linux_arm64
+      file: wat_server-arm64-alpine.zip
       bin: wat_server
     - target: win_x64
       file: wat_server-x86_64-windows.zip
@@ -29,3 +38,6 @@ source:
 
 bin:
   wat_server: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: wasm_language_tools


### PR DESCRIPTION
### Describe your changes
- Added more targets that wasm-language-tools supports but missing in Mason.
- Added `neovim.lspconfig` field.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
