### PR TITLE
(bzl) Add deprecation notice

### DIFF
--- a/packages/bzl/package.yaml
+++ b/packages/bzl/package.yaml
@@ -41,3 +41,6 @@ bin:
 
 neovim:
   lspconfig: bzl
+
+# Package is no longer installable.
+ci_skip: true


### PR DESCRIPTION
### Describe your changes
The bzl server has been broken for a while now. I don't know exactly when it broke but I can't download it. The home page https://bzl.io is also down. It makes sense to deprecate the server so others don't try to install it.

Since it's broken and unusable, I think it's a good idea to remove it once the 3 months deprecation requested by the CONTRIBUTING.md file are up.

<img width="693" height="63" alt="Screenshot 2026-01-13 at 10 45 24 PM" src="https://github.com/user-attachments/assets/bf15cb94-812c-43f7-ac63-5341fff21cc6" />

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
