### PR TITLE
chore(golines): switch to maintained fork

### DIFF
--- a/packages/golines/package.yaml
+++ b/packages/golines/package.yaml
@@ -10,7 +10,7 @@ categories:
   - Formatter
 
 source:
-  id: pkg:golang/github.com/segmentio/golines@v0.13.0
+  id: pkg:golang/github.com/golangci/golines@v0.14.0
 
 bin:
   golines: golang:golines


### PR DESCRIPTION
### Describe your changes
- golines official repo was archived https://github.com/segmentio/golines?tab=readme-ov-file#maintenance--archiving
- golanci has a fork that is maintained https://github.com/golangci/golines

### Issue ticket number and link
https://github.com/mason-org/mason-registry/issues/13203

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
