### PR TITLE
chore(java-test): bump 0.44.0

### DIFF
--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -11,7 +11,9 @@ description: |
 
   - JUnit 4 (v4.8.0+)
   - JUnit 5 (v5.1.0+)
+  - JUnit 6 (v6.0.1+)
   - TestNG (v6.8.0+)
+
 homepage: https://github.com/microsoft/vscode-java-test
 licenses:
   - MIT
@@ -21,7 +23,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:openvsx/vscjava/vscode-java-test@0.43.2
+  id: pkg:openvsx/vscjava/vscode-java-test@0.44.0
   download:
     file: vscjava.vscode-java-test-{{version}}.vsix
 


### PR DESCRIPTION
### Describe your changes
Java test doesn't work with `@QuarkusTest` ( quarkusio/quarkus#48014 ), upgrading to the latest version
fixes this:
https://github.com/microsoft/vscode-java-test/releases/tag/0.44.0 

The previous version (0.43.1) is hard coded on purpose, the release 0.44.0 packs the previous jar.
<!-- Short description of what has been changed and/or added and why -->
### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
<!-- Leave empty if not applicable -->
