### PR TITLE
Manually add black dependency to darker package, as it is no longer included by default

### DIFF
--- a/packages/darker/package.yaml
+++ b/packages/darker/package.yaml
@@ -10,7 +10,7 @@ categories:
   - Formatter
 
 source:
-  id: pkg:pypi/darker@3.0.0?extra=isort,flynt
+  id: pkg:pypi/darker@3.0.0?extra=black,isort,flynt
 
 bin:
   darker: pypi:darker


### PR DESCRIPTION
### Describe your changes
`black` is no longer shipped by default by darker, but it is still the default formatter.
As a result, darker does not work out of the box when used in plugins like conform.nvim

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
