### PR TITLE
Replace sleek formatter source from cargo to github binaries

### DIFF
--- a/packages/sleek/package.yaml
+++ b/packages/sleek/package.yaml
@@ -10,7 +10,16 @@ categories:
   - Formatter
 
 source:
-  id: pkg:cargo/sleek@0.5.0
+  id: pkg:github/nrempel/sleek@v0.5.0
+  asset:
+    - target: linux_x64
+      file: sleek-linux-x86_64
+    - target: darwin_x64
+      file: sleek-macos-x86_64
+    - target: darwin_arm64
+      file: sleek-macos-aarch64
+    - target: win_x64
+      file: sleek-windows-x86_64.exe
 
 bin:
-  sleek: cargo:sleek
+  sleek: "{{source.asset.file}}"


### PR DESCRIPTION
### Describe your changes
I have replaced the sleek formatter source from cargo to github binaries to remove local cargo dependency which allow a simpler installation

### Issue ticket number and link


### Evidence on requirement fulfillment (new packages only)


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots

