### PR TITLE
bump(robotcode): update to v2.2.0

### DIFF
--- a/packages/robotcode/package.yaml
+++ b/packages/robotcode/package.yaml
@@ -11,7 +11,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:pypi/robotcode[all]@2.2.0
+  id: pkg:pypi/robotcode@2.2.0?extra=all
 
 
 schemas:


### PR DESCRIPTION
### Describe your changes
Updated RobotCode to 2.2.0 to be able to run with Python 3.14, which broke old versions. (Is this a breaking change?)

Also, added lspconfig line, which was missing for some reason.

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

Only caveat: while the LSP itself works, I have been unable to configure my environment to work properly with a Python venv. But this is unrelated to this PR.

### Screenshots
<img width="1920" height="1080" alt="Screenshot_20260203_07h58m10s" src="https://github.com/user-attachments/assets/f82737c5-d68e-4fab-b63b-5f175effce77" />

<img width="568" height="198" alt="image" src="https://github.com/user-attachments/assets/c78832a5-de4e-4a4a-a727-c6155e3e2755" />

