### PR TITLE
bump(nixfmt): update to v1.2.0

### DIFF
--- a/packages/nixfmt/package.yaml
+++ b/packages/nixfmt/package.yaml
@@ -10,10 +10,10 @@ categories:
   - Formatter
 
 source:
-  id: pkg:github/NixOS/nixfmt@v0.6.0
+  id: pkg:github/NixOS/nixfmt@v1.2.0
   asset:
     - target: linux_x64
-      file: nixfmt-x86_64-linux
+      file: nixfmt
 
 bin:
   nixfmt: "{{source.asset.file}}"


### PR DESCRIPTION
### Describe your changes
Since [this PR](https://github.com/NixOS/nixfmt/pull/349) and [this PR](https://github.com/NixOS/nixfmt/pull/354) at nixfmt, the compiled binaries are back in the release assets !
I'm not sure why #13005 was closed, but here is another PR to bump the package to the latest version

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
<img width="300" alt="image" src="https://github.com/user-attachments/assets/0a8c3757-a463-411a-b4ee-6facdb86088e" />
