### PR TITLE
fix(pglsp): add .exe for windows

### DIFF
--- a/packages/postgres-language-server/package.yaml
+++ b/packages/postgres-language-server/package.yaml
@@ -12,7 +12,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:github/supabase-community/postgres-language-server@0.19.0
+  id: pkg:github/supabase-community/postgres-language-server@0.20.0
   asset:
     - target: darwin_arm64
       file: postgres-language-server_aarch64-apple-darwin
@@ -25,9 +25,9 @@ source:
     - target: linux_arm64_gnu
       file: postgres-language-server_aarch64-unknown-linux-gnu
     - target: win_x64
-      file: postgres-language-server_x86_64-pc-windows-msvc
+      file: postgres-language-server_x86_64-pc-windows-msvc.exe
     - target: win_arm64
-      file: postgres-language-server_aarch64-pc-windows-msvc
+      file: postgres-language-server_aarch64-pc-windows-msvc.exe
 
 bin:
   postgres-language-server: "{{source.asset.file}}"

--- a/packages/postgrestools/package.yaml
+++ b/packages/postgrestools/package.yaml
@@ -15,7 +15,7 @@ categories:
   - Linter
 
 source:
-  id: pkg:github/supabase-community/postgres-language-server@0.19.0
+  id: pkg:github/supabase-community/postgres-language-server@0.20.0
   asset:
     - target: darwin_arm64
       file: postgrestools_aarch64-apple-darwin
@@ -26,9 +26,9 @@ source:
     - target: linux_arm64_gnu
       file: postgrestools_aarch64-unknown-linux-gnu
     - target: win_x64
-      file: postgrestools_x86_64-pc-windows-msvc
+      file: postgrestools_x86_64-pc-windows-msvc.exe
     - target: win_arm64
-      file: postgrestools_aarch64-pc-windows-msvc
+      file: postgrestools_aarch64-pc-windows-msvc.exe
 
 bin:
   postgrestools: "{{source.asset.file}}"


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

we are now publishing windows binaries with `.exe`.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
