### PR TITLE
fix(asm-lsp): enable locked flag on install

### DIFF
--- a/packages/asm-lsp/package.yaml
+++ b/packages/asm-lsp/package.yaml
@@ -10,7 +10,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:cargo/asm-lsp@0.10.1?locked=false
+  id: pkg:cargo/asm-lsp@0.10.1
 
 schemas:
   lsp: https://raw.githubusercontent.com/bergercookie/asm-lsp/v{{version}}/asm-lsp_config_schema.json


### PR DESCRIPTION
As of right now, asm-lsp doesn't compile on rust 1.93 because of the missing locked flag. This PR adds it

See [the relevant issue on their project](https://github.com/bergercookie/asm-lsp/issues/281). While this particular issue has been just fixed, this project's maintainer has stated that [enabling this flag would be better for future proofing](https://github.com/bergercookie/asm-lsp/pull/283#issue-3911555756)

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.