### PR TITLE
Update tree-sitter-cli homepage link

### DIFF
--- a/packages/tree-sitter-cli/package.yaml
+++ b/packages/tree-sitter-cli/package.yaml
@@ -3,7 +3,7 @@ name: tree-sitter-cli
 description: |
   The Tree-sitter CLI allows you to develop, test, and use Tree-sitter grammars from the command line. It works on
   MacOS, Linux, and Windows.
-homepage: https://github.com/tree-sitter/tree-sitter/blob/master/cli/README.md
+homepage: https://github.com/tree-sitter/tree-sitter/blob/master/crates/cli/README.md
 licenses:
   - MIT
 languages: []


### PR DESCRIPTION
Fixing broken link to homepage.

### Describe your changes
Updating the link for the "homepage" of the tree-sitter-cli package. The original link was incorrect and lead to a 404 page. Noticed it while trying to troubleshoot a separate issue of mine.

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.

This change is for a preexisting package. Change to package.yaml does not include touching the `source` section or adding or changing any keys. In the effort of full transparency, I did not test this change. I did confirm the new link works. I understand if you wish to cancel this pull request because of the lack of testing.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->
