### PR TITLE
feat(ols): add odinfmt binary

### DIFF
--- a/packages/ols/package.yaml
+++ b/packages/ols/package.yaml
@@ -8,6 +8,7 @@ languages:
   - Odin
 categories:
   - LSP
+  - Formatter
 
 source:
   id: pkg:github/DanielGavin/ols@nightly
@@ -15,27 +16,34 @@ source:
     - target: darwin_arm64
       file: ols-arm64-darwin.zip
       bin: ols-arm64-darwin
+      fmt_bin: odinfmt-arm64-darwin
     - target: darwin_x64
       file: ols-x86_64-darwin.zip
       bin: ols-x86_64-darwin
+      fmt_bin: odinfmt-x86_64-darwin
     - target: linux_x64_gnu
       file: ols-x86_64-unknown-linux-gnu.zip
       bin: ols-x86_64-unknown-linux-gnu
+      fmt_bin: odinfmt-x86_64-unknown-linux-gnu
     - target: linux_arm64_gnu
       file: ols-arm64-unknown-linux-gnu.zip
       bin: ols-arm64-unknown-linux-gnu
+      fmt_bin: odinfmt-arm64-unknown-linux-gnu
     - target: win_x86
       file: ols-x86_64-pc-windows-msvc.zip
       bin: ols-x86_64-pc-windows-msvc.exe
+      fmt_bin: odinfmt-x86_64-pc-windows-msvc.exe
     - target: win_x64
       file: ols-x86_64-pc-windows-msvc.zip
       bin: ols-x86_64-pc-windows-msvc.exe
+      fmt_bin: odinfmt-x86_64-pc-windows-msvc.exe
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/DanielGavin/ols/{{version}}/editors/vscode/package.json
 
 bin:
   ols: "{{source.asset.bin}}"
+  odinfmt: "{{source.asset.fmt_bin}}"
 
 neovim:
   lspconfig: ols


### PR DESCRIPTION
### Describe your changes

The `ols` LSP for Odin language from https://github.com/DanielGavin/ols includes both LSP (`ols` binary) and formatter (`odinfmt` binary).  But `odinfmt` binary was not included in the YAML file `packages/ols/package.yaml` file. Therefore, add `odinfmt` binary in the YAML file along with the `ols` binary.

> [!IMPORTANT]
> Even though I haven't tested this on all platforms except Linux, this has to work flawlessly because of the reasons stated below.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

`ols` package already works for other platforms. I just added `odinfmt` binary on already existing `package.yaml`. All I had to do was to add an extra entry with the change `odinfmt` instead of `ols`, and I have also made sure the names for all platforms match up with binaries in the downloaded zip files for all platforms.

I have successfully tested this on Linux (target: linux_x64_gnu). Both the LSP and formatter works on Linux. The formatter also successfully reads JSON config file of `odinfmt`.

> Thank you for this amazing neovim plugin.

### Screenshots
<!-- Leave empty if not applicable -->
