### PR TITLE
fix(tree-sitter-cli): use .zip artifacts on Windows

### DIFF
--- a/packages/tree-sitter-cli/package.yaml
+++ b/packages/tree-sitter-cli/package.yaml
@@ -29,11 +29,11 @@ source:
       file: tree-sitter-linux-arm64.gz
       bin: tree-sitter-linux-arm64
     - target: win_x64
-      file: tree-sitter-windows-x64.gz:tree-sitter-windows-x64.exe.gz
-      bin: tree-sitter-windows-x64.exe
+      file: tree-sitter-cli-windows-x64.zip
+      bin: tree-sitter.exe
     - target: win_x86
-      file: tree-sitter-windows-x86.gz:tree-sitter-windows-x86.exe.gz
-      bin: tree-sitter-windows-x86.exe
+      file: tree-sitter-cli-windows-x86.zip
+      bin: tree-sitter.exe
 
 bin:
   tree-sitter: "{{source.asset.bin}}"


### PR DESCRIPTION
### Describe your changes
If no external tools for extracting `.gz` archives were present on Windows, installation of `tree-sitter-cli` would fail. By switching the Windows releases for `tree-sitter-cli` to the recently added `.zip` versions instead (see https://github.com/tree-sitter/tree-sitter/issues/5378), installation will succeed even if no additional tool is present, as mason will fall back to using `Expand-Archive` for extraction.

Note that the `.zip` archives only exist for the `tree-sitter-cli-<platform>-<arch>` releases, not for the `tree-sitter-<platform>-<arch>` named ones. I think the `tree-sitter` binary both versions contain is exactly the same, and this is only a naming change? See the discussion in https://github.com/tree-sitter/tree-sitter/issues/5378. 


### Issue ticket number and link
Closes https://github.com/mason-org/mason-registry/issues/7020

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`. (N/A)
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->