### PR TITLE
fix(tombi): use github releases instead of pypi

### DIFF
--- a/packages/tombi/package.yaml
+++ b/packages/tombi/package.yaml
@@ -16,7 +16,29 @@ neovim:
   lspconfig: tombi
 
 source:
-  id: pkg:pypi/tombi@0.9.18
+  id: pkg:github/tombi-toml/tombi@v0.9.18
+  asset:
+    - target: darwin_x64
+      file: tombi-cli-{{ version | strip_prefix "v" }}-x86_64-apple-darwin.gz
+      bin: tombi-cli-{{ version | strip_prefix "v" }}-x86_64-apple-darwin
+    - target: darwin_arm64
+      file: tombi-cli-{{ version | strip_prefix "v" }}-aarch64-apple-darwin.gz
+      bin: tombi-cli-{{ version | strip_prefix "v" }}-aarch64-apple-darwin
+    - target: linux_x64
+      file: tombi-cli-{{ version | strip_prefix "v" }}-x86_64-unknown-linux-musl.gz
+      bin: tombi-cli-{{ version | strip_prefix "v" }}-x86_64-unknown-linux-musl
+    - target: linux_arm64
+      file: tombi-cli-{{ version | strip_prefix "v" }}-aarch64-unknown-linux-musl.gz
+      bin: tombi-cli-{{ version | strip_prefix "v" }}-aarch64-unknown-linux-musl
+    - target: linux_armv7_gnu
+      file: tombi-cli-{{ version | strip_prefix "v" }}-arm-unknown-linux-gnueabihf.gz
+      bin: tombi-cli-{{ version | strip_prefix "v" }}-arm-unknown-linux-gnueabihf
+    - target: win_x64
+      file: tombi-cli-{{ version | strip_prefix "v" }}-x86_64-pc-windows-msvc.zip
+      bin: tombi.exe
+    - target: win_arm64
+      file: tombi-cli-{{ version | strip_prefix "v" }}-aarch64-pc-windows-msvc.zip
+      bin: tombi.exe
 
 bin:
-  tombi: pypi:tombi
+  tombi: "{{source.asset.bin}}"


### PR DESCRIPTION
### Describe your changes
`tombi` is a Rust binary that doesn't require Python. The current PyPI-based installation unnecessarily requires a Python runtime and virtual environment, causing installation failures on systems without `python3-venv`.

This change uses pre-built binaries from GitHub Releases, eliminating the Python dependency.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
