### PR TITLE
chore(java-test): bump 0.45.0

### DIFF
--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -26,15 +26,8 @@ source:
   id: pkg:openvsx/vscjava/vscode-java-test@0.45.0
   download:
     file: vscjava.vscode-java-test-{{version}}.vsix
-    plugin_version: 0.43.1
-
-  version_overrides:
-    - constraint: semver:<=0.43.1
-      id: pkg:openvsx/vscjava/vscode-java-test@0.43.1
-      download:
-        file: vscjava.vscode-java-test-{{version}}.vsix
-        plugin_version: "{{version}}"
+    plugin_version: 0.45.0
 
 share:
   java-test/: extension/server/
-  java-test/com.microsoft.java.test.plugin.jar: extension/server/com.microsoft.java.test.plugin-{{ source.download.plugin_version }}.jar
+  java-test/com.microsoft.java.test.plugin.jar: extension/server/com.microsoft.java.test.plugin-0.43.1.jar

--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -23,7 +23,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:openvsx/vscjava/vscode-java-test@0.44.0
+  id: pkg:openvsx/vscjava/vscode-java-test@0.45.0
   download:
     file: vscjava.vscode-java-test-{{version}}.vsix
     plugin_version: 0.43.1

--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -26,7 +26,6 @@ source:
   id: pkg:openvsx/vscjava/vscode-java-test@0.45.0
   download:
     file: vscjava.vscode-java-test-{{version}}.vsix
-    plugin_version: 0.45.0
 
 share:
   java-test/: extension/server/

--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -26,7 +26,15 @@ source:
   id: pkg:openvsx/vscjava/vscode-java-test@0.45.0
   download:
     file: vscjava.vscode-java-test-{{version}}.vsix
+    plugin_version: 0.43.1
+
+version_overrides:
+  - constraint: semver:<=0.43.1
+    id: pkg:openvsx/vscjava/vscode-java-test@0.43.1
+    download:
+      file: vscjava.vscode-java-test-{{version}}.vsix
+      plugin_version: "{{version}}"
 
 share:
   java-test/: extension/server/
-  java-test/com.microsoft.java.test.plugin.jar: extension/server/com.microsoft.java.test.plugin-0.43.1.jar
+  java-test/com.microsoft.java.test.plugin.jar: extension/server/com.microsoft.java.test.plugin-{{ source.download.plugin_version }}.jar

--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -28,12 +28,12 @@ source:
     file: vscjava.vscode-java-test-{{version}}.vsix
     plugin_version: 0.43.1
 
-version_overrides:
-  - constraint: semver:<=0.43.1
-    id: pkg:openvsx/vscjava/vscode-java-test@0.43.1
-    download:
-      file: vscjava.vscode-java-test-{{version}}.vsix
-      plugin_version: "{{version}}"
+  version_overrides:
+    - constraint: semver:<=0.43.1
+      id: pkg:openvsx/vscjava/vscode-java-test@0.43.1
+      download:
+        file: vscjava.vscode-java-test-{{version}}.vsix
+        plugin_version: "{{version}}"
 
 share:
   java-test/: extension/server/


### PR DESCRIPTION
### Describe your changes
The java test package has been updated to the latest version.
The fixes are listed here: https://github.com/microsoft/vscode-java-test/releases/0.45.0

The version `0.43.2` is hardcoded in several spots, as per the `package.json` here:
https://github.com/microsoft/vscode-java-test/compare/0.44.0...0.45.0#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R58
 
### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
