### PR TITLE
feat(phpantom_lsp): add package (#14312)

### DIFF
--- a/packages/phpantom_lsp/package.yaml
+++ b/packages/phpantom_lsp/package.yaml
@@ -1,0 +1,37 @@
+---
+name: phpantom_lsp
+description: |
+  A lightweight PHP language server with deep type intelligence — generics, Laravel support, and PHPStan annotations.
+  Written in Rust for fast startup and low memory use.
+homepage: https://github.com/AJenbo/phpantom_lsp
+licenses:
+  - MIT
+languages:
+  - PHP
+categories:
+  - LSP
+
+source:
+  id: pkg:github/AJenbo/phpantom_lsp@0.7.0
+  asset:
+    - target: darwin_arm64
+      file: phpantom_lsp-aarch64-apple-darwin.tar.gz
+      bin: phpantom_lsp
+    - target: darwin_x64
+      file: phpantom_lsp-x86_64-apple-darwin.tar.gz
+      bin: phpantom_lsp
+    - target: linux_arm64_gnu
+      file: phpantom_lsp-aarch64-unknown-linux-gnu.tar.gz
+      bin: phpantom_lsp
+    - target: linux_x64_gnu
+      file: phpantom_lsp-x86_64-unknown-linux-gnu.tar.gz
+      bin: phpantom_lsp
+    - target: win_x64
+      file: phpantom_lsp-x86_64-pc-windows-msvc.zip
+      bin: phpantom_lsp.exe
+
+bin:
+  phpantom_lsp: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: phpantom_lsp


### PR DESCRIPTION


### Describe your changes

A lightweight PHP language server with deep type intelligence — generics, Laravel support, and PHPStan annotations. Written in Rust for fast startup and low memory use.

### Issue ticket number and link

Closes #14312

### Evidence on requirement fulfillment (new packages only)

  - ≥ 100 GitHub stars: [AJenbo/phpantom_lsp](https://github.com/AJenbo/phpantom_lsp) has 555 stars.
  - Approved at nvim-lspconfig: configuration merged in [neovim/nvim-lspconfig#4362](https://github.com/neovim/nvim-lspconfig/pull/4362) under the key phpantom_lsp.


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots

<img width="635" height="1347" alt="image" src="https://github.com/user-attachments/assets/891147a5-86fe-4b78-a91e-98a7d77a3d9f" />
