### PR TITLE
feat: add ctags-lsp

### DIFF
--- a/packages/ctags-lsp/package.yaml
+++ b/packages/ctags-lsp/package.yaml
@@ -1,0 +1,37 @@
+---
+name: ctags-lsp
+description: A simple LSP server wrapping universal-ctags. Provides code completion, go-to-definition, and document/workspace symbols.
+homepage: https://github.com/netmute/ctags-lsp
+licenses:
+  - MIT
+languages: []
+categories:
+  - LSP
+
+source:
+  id: pkg:github/netmute/ctags-lsp@v0.11.0
+  asset:
+    - target: darwin_arm64
+      file: ctags-lsp_Darwin_arm64.tar.gz
+      bin: ctags-lsp
+    - target: darwin_x64
+      file: ctags-lsp_Darwin_x86_64.tar.gz
+      bin: ctags-lsp
+    - target: linux_arm64
+      file: ctags-lsp_Linux_arm64.tar.gz
+      bin: ctags-lsp
+    - target: linux_x64
+      file: ctags-lsp_Linux_x86_64.tar.gz
+      bin: ctags-lsp
+    - target: win_arm64
+      file: ctags-lsp_Windows_arm64.zip
+      bin: ctags-lsp.exe
+    - target: win_x64
+      file: ctags-lsp_Windows_x86_64.zip
+      bin: ctags-lsp.exe
+
+bin:
+  ctags-lsp: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: ctags_lsp


### PR DESCRIPTION
### Describe your changes

This adds [ctags-lsp](https://github.com/netmute/ctags-lsp), a small LSP
server wrapping universal-ctags. It exposes completion, go-to-definition,
and document/workspace symbols — useful as a generic fallback for
languages that lack a dedicated language server.

The package follows the goreleaser asset naming
(`ctags-lsp_<OS>_<ARCH>.{tar.gz,zip}`), mapped to mason's six target
slots (darwin / linux / windows × arm64 / x86_64).

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)

- <https://github.com/netmute/ctags-lsp> has 138 stars as of writing.
- 19 releases, actively maintained (latest v0.11.0, January 2026).

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`. (lspconfig entry is pending in neovim/nvim-lspconfig#4399)
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
<!-- Leave empty if not applicable -->