### PR TITLE
feat: add dexter LSP (for Elixir)

### DIFF
--- a/packages/dexter/package.yaml
+++ b/packages/dexter/package.yaml
@@ -12,9 +12,6 @@ categories:
 source:
   id: pkg:github/remoteoss/dexter@v0.6.0
   asset:
-    - target: darwin_x64
-      file: dexter_Darwin_x86_64.tar.gz
-      bin: dexter_Darwin_x86_64/dexter
     - target: darwin_arm64
       file: dexter_Darwin_arm64.tar.gz
       bin: dexter_Darwin_arm64/dexter

--- a/packages/dexter/package.yaml
+++ b/packages/dexter/package.yaml
@@ -1,0 +1,32 @@
+---
+name: dexter
+description: A fast, full-featured Elixir LSP optimized for large codebases.
+homepage: https://github.com/remoteoss/dexter
+licenses:
+  - MIT
+languages:
+  - Elixir
+categories:
+  - LSP
+
+source:
+  id: pkg:github/remoteoss/dexter@v0.6.0
+  asset:
+    - target: darwin_x64
+      file: dexter_Darwin_x86_64.tar.gz
+      bin: dexter_Darwin_x86_64/dexter
+    - target: darwin_arm64
+      file: dexter_Darwin_arm64.tar.gz
+      bin: dexter_Darwin_arm64/dexter
+    - target: linux_x64
+      file: dexter_Linux_x86_64.tar.gz
+      bin: dexter_Linux_x86_64/dexter
+    - target: linux_arm64
+      file: dexter_Linux_arm64.tar.gz
+      bin: dexter_Linux_arm64/dexter
+
+bin:
+  dexter: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: dexter

--- a/packages/dexter/package.yaml
+++ b/packages/dexter/package.yaml
@@ -24,6 +24,3 @@ source:
 
 bin:
   dexter: "{{source.asset.bin}}"
-
-neovim:
-  lspconfig: dexter


### PR DESCRIPTION
### Describe your changes
Add Dexter to the registry as a new Elixir LSP package using its GitHub release assets. The manifest points Mason at the nested `dexter` binary inside each release tarball and includes `neovim.lspconfig: dexter` metadata.

### Issue ticket number and link

### Evidence on requirement fulfillment (new packages only)
https://github.com/remoteoss/dexter

The repository currently has 248 GitHub stars, which satisfies the 100-star requirement in `CONTRIBUTING.md`.

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
  - there is no package available at nvim-lspconfig
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

Local verification:
- Installed `dexter` from this local `file:` registry into an isolated Mason root with headless Neovim.
- Confirmed `which dexter` and `vim.fn.exepath('dexter')` resolved to Mason's installed binary, not the global `mise` install.
- Ran `dexter --help` from the Mason-managed binary successfully.
- Opened a temporary Elixir project in headless Neovim and confirmed the `dexter` LSP attached successfully.

### Screenshots

<img width="3164" height="2070" alt="CleanShot 2026-04-23 at 16 22 11@2x" src="https://github.com/user-attachments/assets/70ab0561-3c75-4f19-ba2b-7d9438c04161" />

<img width="3164" height="2070" alt="CleanShot 2026-04-23 at 16 27 30@2x" src="https://github.com/user-attachments/assets/0f9e0539-34a7-4a86-abdf-e1a335b25382" />
<img width="3164" height="2070" alt="CleanShot 2026-04-23 at 16 27 22@2x" src="https://github.com/user-attachments/assets/ca5b0b65-68b4-4346-a3aa-4feb83546e45" />

<img width="3164" height="2070" alt="CleanShot 2026-04-23 at 16 34 25@2x" src="https://github.com/user-attachments/assets/75ce641f-85cb-4fbf-9e68-aa5835a1a03b" />

<img width="3164" height="2070" alt="CleanShot 2026-04-23 at 16 34 41@2x" src="https://github.com/user-attachments/assets/8e33c72e-76f8-400f-b8b6-c4025a192395" />




