### PR TITLE
fix(kotlin-lsp): bump to version v262.4739.0 and adapt to packaging changes

### DIFF
--- a/packages/kotlin-lsp/package.yaml
+++ b/packages/kotlin-lsp/package.yaml
@@ -12,32 +12,32 @@ categories:
 source:
   # renovate:versioning=regex:^kotlin-lsp/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
   # renovate:datasource=github-releases
-  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v262.2310.0
+  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v262.4739.0
   download:
     - target: darwin_x64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-mac-x64.zip
-      bin: kotlin-lsp.sh
+        kotlin-lsp.sit: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.sit
+      bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: darwin_arm64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-mac-aarch64.zip
-      bin: kotlin-lsp.sh
+        kotlin-lsp.sit: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.sit
+      bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: linux_x64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-linux-x64.zip
-      bin: kotlin-lsp.sh
+        kotlin-lsp.tar.gz: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.tar.gz
+      bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: linux_arm64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-linux-aarch64.zip
-      bin: kotlin-lsp.sh
+        kotlin-lsp.tar.gz: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.tar.gz
+      bin: kotlin-server-{{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: win_x64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-win-x64.zip
-      bin: kotlin-lsp.cmd
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.win.zip
+      bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server.exe
     - target: win_arm64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-lsp-{{ version | strip_prefix "kotlin-lsp/v" }}-win-aarch64.zip
-      bin: kotlin-lsp.cmd
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.win.zip
+      bin: kotlin-server-{{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server.exe
 
 bin:
   kotlin-lsp: "{{source.download.bin}}"

--- a/packages/kotlin-lsp/package.yaml
+++ b/packages/kotlin-lsp/package.yaml
@@ -40,7 +40,7 @@ source:
       bin: kotlin-server-{{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server.exe
 
 bin:
-  kotlin-lsp: "{{source.download.bin}}"
+  intellij-server: "{{source.download.bin}}"
 
 neovim:
   lspconfig: kotlin_lsp

--- a/packages/kotlin-lsp/package.yaml
+++ b/packages/kotlin-lsp/package.yaml
@@ -16,11 +16,11 @@ source:
   download:
     - target: darwin_x64
       files:
-        kotlin-lsp.sit: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.sit
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.sit
       bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: darwin_arm64
       files:
-        kotlin-lsp.sit: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.sit
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.sit
       bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: linux_x64
       files:

--- a/packages/kotlin-lsp/package.yaml
+++ b/packages/kotlin-lsp/package.yaml
@@ -33,11 +33,11 @@ source:
     - target: win_x64
       files:
         kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.win.zip
-      bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server.exe
+      bin: bin/intellij-server.exe
     - target: win_arm64
       files:
         kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.win.zip
-      bin: kotlin-server-{{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server.exe
+      bin: bin/intellij-server.exe
 
 bin:
   intellij-server: "{{source.download.bin}}"


### PR DESCRIPTION
### Describe your changes
- bin/intellij-server is used now as a primary binary (kotlin-lsp.sh or kotlin-lsp.cmd has been deprecated)
- download extensions are now platform specific
- packages now include a new kotlin-server-VERSION prefix that will now be stripped.
 
### Issue ticket number and link
Automatic verison update failed: https://github.com/mason-org/mason-registry/pull/14785

### Checklist before requesting a review
- [X] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
