### PR TITLE
add statix

### DIFF
--- a/packages/statix/package.yaml
+++ b/packages/statix/package.yaml
@@ -5,12 +5,12 @@ homepage: https://github.com/oppiliappan/statix
 licenses:
   - MIT
 languages:
-  - nix
+  - Nix
 categories:
   - Linter
 
 source:
-  id: pkg:cargo/statix@4.8.3
+  id: pkg:cargo/statix@v0.5.8?repository_url=https://github.com/oppiliappan/statix
 
 bin:
   statix: cargo:statix

--- a/packages/statix/package.yaml
+++ b/packages/statix/package.yaml
@@ -1,0 +1,16 @@
+---
+name: statix
+description: lints and suggestions for the nix programming language
+homepage: https://github.com/oppiliappan/statix
+licenses:
+  - MIT
+languages:
+  - nix
+categories:
+  - Linter
+
+source:
+  id: pkg:cargo/statix@4.8.3
+
+bin:
+  statix: cargo:statix

--- a/packages/statix/package.yaml
+++ b/packages/statix/package.yaml
@@ -14,3 +14,6 @@ source:
 
 bin:
   statix: cargo:statix
+
+neovim:
+  lspconfig: statix


### PR DESCRIPTION
### Describe your changes
Add statix nix linter using cargo

### Issue ticket number and link
#14807 

### Evidence on requirement fulfillment (new packages only)
The repo has 889 stars on https://github.com/oppiliappan/statix

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Local verification:
- Installed statix from this local file: registry into Neovim.
- Confirmed which statix and vim.fn.exepath('statix') resolved to Mason's installed binary, not the global mise install.
- Ran statix --help from the Mason-managed binary successfully.
- Opened a temporary nix project in headless Neovim and confirmed the statix attached successfully.


### Screenshots
<img width="2458" height="1273" alt="image" src="https://github.com/user-attachments/assets/3eb33fb7-df73-4eed-857e-307c0ccc0a2f" />
<img width="2458" height="1273" alt="image" src="https://github.com/user-attachments/assets/8ce01f02-545d-482a-a5a9-30d98ac47613" />
<img width="2458" height="1273" alt="image" src="https://github.com/user-attachments/assets/b883cdcc-cbcd-4e1b-8665-82533d813cea" />
<img width="2458" height="1273" alt="image" src="https://github.com/user-attachments/assets/e391bf39-9531-43bd-89ad-a514d3b5f072" />
<img width="2458" height="1273" alt="image" src="https://github.com/user-attachments/assets/a921db40-cf38-4332-99fa-4f8ea8c7ee79" />

