### PR TITLE
feat: add panache

### DIFF
--- a/packages/panache/package.yaml
+++ b/packages/panache/package.yaml
@@ -1,0 +1,51 @@
+---
+name: panache
+description: An LSP, formatter, and linter for Markdown, Quarto, and R Markdown.
+homepage: https://panache.bz
+licenses:
+  - MIT
+languages:
+  - Markdown
+  - Quarto
+  - R Markdown
+categories:
+  - LSP
+  - Formatter
+  - Linter
+
+source:
+  id: pkg:github/jolars/panache@v2.43.1
+  asset:
+    - target: darwin_arm64
+      file: panache-aarch64-apple-darwin.tar.gz
+      bin: panache
+    - target: darwin_x64
+      file: panache-x86_64-apple-darwin.tar.gz
+      bin: panache
+    - target: linux_arm64_gnu
+      file: panache-aarch64-unknown-linux-gnu.tar.gz
+      bin: panache
+    - target: linux_x64_gnu
+      file: panache-x86_64-unknown-linux-gnu.tar.gz
+      bin: panache
+    - target: linux_arm64_musl
+      file: panache-aarch64-unknown-linux-musl.tar.gz
+      bin: panache
+    - target: linux_x64_musl
+      file: panache-x86_64-unknown-linux-musl.tar.gz
+      bin: panache
+    - target: win_arm64
+      file: panache-aarch64-pc-windows-msvc.zip
+      bin: panache.exe
+    - target: win_x64
+      file: panache-x86_64-pc-windows-msvc.zip
+      bin: panache.exe
+
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/jolars/panache/{{version}}/editors/code/package.json
+
+bin:
+  panache: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: panache


### PR DESCRIPTION
### Describe your changes

Adds [`panache`](https://panache.bz), a language server, formatter, and linter for Markdown, Quarto, and R Markdown. The package sources cross-platform GitHub release assets (macOS x64/arm64, Linux x64/arm64 (gnu and musl), Windows
x64/arm64) and includes `neovim.lspconfig: panache` plus a `schemas.lsp` pointer at the bundled VS Code extension's `package.json`.

I'm the author of Panache.

### Issue ticket number and link

N/A

### Evidence on requirement fulfillment (new packages only)

- <https://github.com/jolars/panache> currently has 102 GitHub stars, satisfying the 100-star requirement.
- nvim-lspconfig integration: was added in <https://github.com/neovim/nvim-lspconfig/commit/f6738ef65dabade340b473d4ff2a1ad3352c10e7>

### Checklist before requesting a review

- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

Local verification on NixOS, inside an FHS environment built with
`pkgs.buildFHSEnv`:

- `:MasonInstall panache` pulled the default `linux_x64_gnu` tarball, unpacked it, and linked `mason/bin/panache` correctly.
- `panache --version` reports `panache 2.43.1`.
- `panache lsp --help` confirms the LSP entry point is reachable.
- `mason-schemas/` was populated from the `schemas.lsp` URL, confirming the VS Code extension's `package.json` resolves at the version tag.
- `package.yaml` validates against `https://github.com/mason-org/registry-schema/releases/latest/download/package.schema.json`.

### Screenshots

N/A
