### PR TITLE
Add that harper-ls supports LaTeX

### DIFF
--- a/packages/harper-ls/package.yaml
+++ b/packages/harper-ls/package.yaml
@@ -18,6 +18,7 @@ languages:
   - TOML
   - Lua
   - Java
+  - LaTeX
 categories:
   - LSP
 


### PR DESCRIPTION
### Describe your changes
`harper-ls` supports (since https://github.com/Automattic/harper/pull/2689, see https://github.com/Automattic/harper/issues/56) `TeX` and derivative languages (including `LaTeX`). This PR includes that support in the package spec for the language server.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
