### PR TITLE
security: add minimumReleaseAge for all datasources

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,6 +1,19 @@
 {
     extends: ["github>mason-org/registry-renovate-config"],
+    // Order of rules matter, later rules override (merge) previous ones.
     packageRules: [
+        {
+            "matchDatasources": ["*"],
+            "minimumReleaseAge": "1 day"
+        },
+        {
+            /*
+            * npm packages less than 72 hours (3 days) old can be unpublished from the npm registry, which could result
+            * in a service impact if they have already been upgraded.
+            */
+            "matchDatasources": ["npm"],
+            "minimumReleaseAge": "3 days"
+        },
         {
             matchDepNames: ["cucumber-language-server"],
             allowedVersions: "!/^1\\.[34]\\.0/"


### PR DESCRIPTION
This adds a 1 day default minimum release age for all datasources and extending that to 3 days for npm packages for
reasons listed in the comment. Since we have Renovate's automerge config enabled, Renovate will still immediately create
PRs as soon as it detects version upgrade but will wait with automerge until the mandated minimumReleaseAge has elapsed.
