### PR TITLE
Added JLS (java)

### DIFF
--- a/packages/jls/package.yaml
+++ b/packages/jls/package.yaml
@@ -17,8 +17,8 @@ source:
       file:
         - jls-macos-aarch64.tar.gz
         - jls-macos-aarch64.tar.gz.sha256
-      lsp: lang_server_mac.sh
-      dap: debug_adapter_mac.sh
+      lsp: exec:lang_server_mac.sh
+      dap: exec:debug_adapter_mac.sh
     - target: linux_x64_gnu
       file:
         - jls-linux-x64.tar.gz

--- a/packages/jls/package.yaml
+++ b/packages/jls/package.yaml
@@ -1,0 +1,41 @@
+---
+name: jls
+description: Java language server using Java compiler API, optimized for Neovim.
+homepage: https://github.com/idelice/jls
+licenses:
+  - MIT
+languages:
+  - Java
+categories:
+  - LSP
+  - DAP
+
+source:
+  id: pkg:github/idelice/jls@v0.5.0
+  supported_platforms:
+    - darwin_arm64
+    - linux_x64_gnu
+    - win_x64
+  asset:
+    - target: darwin_arm64
+      file:
+        - jls-macos-aarch64.tar.gz
+        - jls-macos-aarch64.tar.gz.sha256
+      lsp: lang_server_mac.sh
+      dap: debug_adapter_mac.sh
+    - target: linux_x64_gnu
+      file:
+        - jls-linux-x64.tar.gz
+        - jls-linux-x64.tar.gz.sha256
+      lsp: lang_server_linux.sh
+      dap: debug_adapter_linux.sh
+    - target: win_x64
+      file:
+        - jls-windows-x64.zip
+        - jls-windows-x64.zip.sha256
+      lsp: lang_server_windows.cmd
+      dap: debug_adapter_windows.cmd
+
+bin:
+  jls: "{{source.asset.lsp}}"
+  jls-debug-adapter: "{{source.asset.dap}}"

--- a/packages/jls/package.yaml
+++ b/packages/jls/package.yaml
@@ -12,10 +12,6 @@ categories:
 
 source:
   id: pkg:github/idelice/jls@v0.5.1
-  supported_platforms:
-    - darwin_arm64
-    - linux_x64_gnu
-    - win_x64
   asset:
     - target: darwin_arm64
       file:

--- a/packages/jls/package.yaml
+++ b/packages/jls/package.yaml
@@ -23,8 +23,8 @@ source:
       file:
         - jls-linux-x64.tar.gz
         - jls-linux-x64.tar.gz.sha256
-      lsp: lang_server_linux.sh
-      dap: debug_adapter_linux.sh
+      lsp: exec:lang_server_linux.sh
+      dap: exec:debug_adapter_linux.sh
     - target: win_x64
       file:
         - jls-windows-x64.zip

--- a/packages/jls/package.yaml
+++ b/packages/jls/package.yaml
@@ -11,7 +11,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:github/idelice/jls@v0.5.0
+  id: pkg:github/idelice/jls@v0.5.1
   supported_platforms:
     - darwin_arm64
     - linux_x64_gnu


### PR DESCRIPTION


### Describe your changes
Tested locally with `file:` registry — `:MasonInstall jls` installs successfully on darwin_arm64.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
Requirement met: 112 GitHub stars (>100): https://github.com/idelice/jls 

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ x] I have successfully tested installation of the package.
- [ x] I have successfully tested the package after installation.
```
[INFO  Fri May 22 11:23:45 2026] ...zy/mason.nvim/lua/mason-core/installer/InstallRunner.lua:40: Executing installer for Package(name=jls) {
  debug = false,
  force = false,
  strict = false
}
[INFO  Fri May 22 11:23:50 2026] ...zy/mason.nvim/lua/mason-core/installer/InstallRunner.lua:86: Installation succeeded for Package(name=jls)
```


### Screenshots
<!-- Leave empty if not applicable -->
