### PR TITLE
feat: add slang-server

### DIFF
--- a/packages/slang-server/package.yaml
+++ b/packages/slang-server/package.yaml
@@ -13,11 +13,11 @@ categories:
 source:
   id: pkg:github/hudson-trading/slang-server@v0.2.6
   asset:
-    - target: linux_x64
+    - target: linux_x64_gnu
       file: slang-server-old-linux-x64-gcc.tar.gz
       bin: slang-server
 
-    - target: linux_arm64
+    - target: linux_arm64_gnu
       file: slang-server-linux-arm64-clang.tar.gz
       bin: slang-server
 

--- a/packages/slang-server/package.yaml
+++ b/packages/slang-server/package.yaml
@@ -1,0 +1,40 @@
+---
+name: slang-server
+description: A SystemVerilog language server based on the Slang library.
+homepage: https://github.com/hudson-trading/slang-server
+licenses:
+  - MIT
+languages:
+  - SystemVerilog
+  - Verilog
+categories:
+  - LSP
+
+source:
+  id: pkg:github/hudson-trading/slang-server@v0.2.6
+  asset:
+    - target: linux_x64
+      file: slang-server-old-linux-x64-gcc.tar.gz
+      bin: slang-server
+
+    - target: linux_arm64
+      file: slang-server-linux-arm64-clang.tar.gz
+      bin: slang-server
+
+    - target: win_x64
+      file: slang-server-windows-x64.zip
+      bin: slang-server.exe
+
+    - target: win_arm64
+      file: slang-server-windows-arm64.zip
+      bin: slang-server.exe
+
+    - target: darwin_arm64
+      file: slang-server-macos.tar.gz
+      bin: slang-server
+
+bin:
+  slang-server: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: slang_server


### PR DESCRIPTION
### Describe your changes
Add Slang Server, a SystemVerilog language server:
https://github.com/hudson-trading/slang-server

### Issue ticket number and link

### Evidence on requirement fulfillment (new packages only)
At least 100 stars on GitHub. :heavy_check_mark: 
https://github.com/hudson-trading/slang-server/stargazers
Be approved at [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig). :heavy_check_mark: 
https://github.com/neovim/nvim-lspconfig/pull/4441


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ :heavy_check_mark: ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ :heavy_check_mark: ] I have successfully tested installation of the package.
- [ :heavy_check_mark: ] I have successfully tested the package after installation.

### Screenshots

<img width="570" height="294" alt="image" src="https://github.com/user-attachments/assets/19a31616-8597-44e1-b395-45ed3077ab50" />

<img width="663" height="369" alt="image" src="https://github.com/user-attachments/assets/3ded5a86-2e8c-40f7-a9ce-a51e31c845a9" />
