### PR TITLE
feat: Add Vespa Language Server

### DIFF
--- a/packages/vespa-language-server/package.yaml
+++ b/packages/vespa-language-server/package.yaml
@@ -17,8 +17,8 @@ source:
   asset:
     file: vespa-language-server_{{ version | strip_prefix "lsp-v" }}.jar
 
-share:
-  vespa-language-server/vespa-language-server.jar: vespa-language-server_{{ version | strip_prefix "lsp-v" }}.jar
+bin:
+  vespa-language-server: java-jar:vespa-language-server_{{ version | strip_prefix "lsp-v" }}.jar
 
 neovim:
   lspconfig: vespa_ls

--- a/packages/vespa-language-server/package.yaml
+++ b/packages/vespa-language-server/package.yaml
@@ -1,0 +1,24 @@
+---
+name: vespa-language-server
+description: |
+  Language support for the Vespa Schema language.
+homepage: https://github.com/vespa-engine/vespa/tree/master/integration/schema-language-server
+licenses:
+  - Apache-2.0
+languages:
+  - sd
+  - yql
+categories:
+  - LSP
+
+source:
+  # renovate:versioning=regex:^lsp-v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
+  id: pkg:github/vespa-engine/vespa@lsp-v2.4.9
+  asset:
+    file: vespa-language-server_{{ version | strip_prefix "lsp-v" }}.jar
+
+share:
+  vespa-language-server/vespa-language-server.jar: vespa-language-server_{{ version | strip_prefix "lsp-v" }}.jar
+
+neovim:
+  lspconfig: vespa_ls


### PR DESCRIPTION
### Describe your changes
Added Vespa Language server to the registry.

### Issue ticket number and link
NA

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->
Have at least 100 stars on Github: https://github.com/vespa-engine/vespa
Is approved at nvim-lspconfig: https://github.com/neovim/nvim-lspconfig/blob/master/lsp/vespa_ls.lua
Officially recommended by a company: https://docs.vespa.ai/en/applications/ide-support.html

### Checklist before requesting a review
- [X] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation. (Needs the [PR](https://github.com/mason-org/mason-lspconfig.nvim/pull/676) to be merged to automatically start the lsp)

### Screenshots
LSP started and here is a screenshot of working semantic tokens.
<img width="969" height="692" alt="Screenshot 2026-05-30 at 10 23 35" src="https://github.com/user-attachments/assets/a5ee120c-26e6-4fc6-a7d9-f84ec3234896" />
