### PR TITLE
chore: bump kotlin-lsp to v262.7569.0

### DIFF
--- a/packages/kotlin-lsp/package.yaml
+++ b/packages/kotlin-lsp/package.yaml
@@ -12,7 +12,7 @@ categories:
 source:
   # renovate:versioning=regex:^kotlin-lsp/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
   # renovate:datasource=github-releases
-  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v262.4739.0
+  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v262.7569.0
   download:
     - target: darwin_x64
       files:


### PR DESCRIPTION
### Describe your changes
Updated kotlin-lsp version to reflect latest release at https://github.com/Kotlin/kotlin-lsp 


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.


