### PR TITLE
feat(dexter): add lspconfig configuration

### DIFF
--- a/packages/dexter/package.yaml
+++ b/packages/dexter/package.yaml
@@ -24,3 +24,6 @@ source:
 
 bin:
   dexter: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: dexter


### PR DESCRIPTION
### Describe your changes

Addresses the remaining concern regarding Dexter raised in https://github.com/mason-org/mason-registry/pull/14726#discussion_r3133915142.

### Issue ticket number and link

Prerequisites fulfilled in https://github.com/neovim/nvim-lspconfig/pull/4421.

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->

<img width="403" height="106" alt="image" src="https://github.com/user-attachments/assets/d60d166f-ec36-4eae-b490-61225a39c8de" />
<img width="371" height="196" alt="image" src="https://github.com/user-attachments/assets/4db46e25-325a-4752-959e-8fbdbff68b58" />
<img width="798" height="876" alt="image" src="https://github.com/user-attachments/assets/11ef6107-c801-4b2d-9505-4d01973a6a1c" />



