### PR TITLE
bump(vscode-spring-boot-tools): update to 2.2.0

### DIFF
--- a/packages/vscode-spring-boot-tools/package.yaml
+++ b/packages/vscode-spring-boot-tools/package.yaml
@@ -14,7 +14,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:openvsx/VMware/vscode-spring-boot@2.2.2026061100
+  id: pkg:openvsx/VMware/vscode-spring-boot@2.2.0
   download:
     file: VMware.vscode-spring-boot-{{version}}.vsix
 

--- a/packages/vscode-spring-boot-tools/package.yaml
+++ b/packages/vscode-spring-boot-tools/package.yaml
@@ -18,9 +18,6 @@ source:
   download:
     file: VMware.vscode-spring-boot-{{version}}.vsix
 
-schemas:
-  lsp: vscode:https://raw.githubusercontent.com/spring-projects/spring-tools/vscode-spring-boot-{{version}}-RC1/vscode-extensions/vscode-spring-boot/package.json
-
 share:
   vscode-spring-boot-tools/jdtls/: extension/jars/
   vscode-spring-boot-tools/language-server.jar: extension/language-server/spring-boot-language-server-{{version}}-SNAPSHOT-exec.jar

--- a/packages/vscode-spring-boot-tools/package.yaml
+++ b/packages/vscode-spring-boot-tools/package.yaml
@@ -20,4 +20,4 @@ source:
 
 share:
   vscode-spring-boot-tools/jdtls/: extension/jars/
-  vscode-spring-boot-tools/language-server.jar: extension/language-server/spring-boot-language-server-{{version}}-SNAPSHOT-exec.jar
+  vscode-spring-boot-tools/language-server.jar: extension/language-server/spring-boot-language-server-2.2.0-SNAPSHOT-exec.jar

--- a/packages/vscode-spring-boot-tools/package.yaml
+++ b/packages/vscode-spring-boot-tools/package.yaml
@@ -14,7 +14,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:openvsx/VMware/vscode-spring-boot@1.63.0
+  id: pkg:openvsx/VMware/vscode-spring-boot@2.2.2026061100
   download:
     file: VMware.vscode-spring-boot-{{version}}.vsix
 

--- a/packages/vscode-spring-boot-tools/package.yaml
+++ b/packages/vscode-spring-boot-tools/package.yaml
@@ -20,4 +20,4 @@ source:
 
 share:
   vscode-spring-boot-tools/jdtls/: extension/jars/
-  vscode-spring-boot-tools/language-server.jar: extension/language-server/spring-boot-language-server-2.2.0-SNAPSHOT-exec.jar
+  vscode-spring-boot-tools/language-server.jar: extension/language-server/spring-boot-language-server-{{version}}-SNAPSHOT-exec.jar


### PR DESCRIPTION
Beep boop. I've updated vscode-spring-boot-tools to 2.2.2026061100.

<sup>` 🤖 This is an automated comment. `</sup>