### PR TITLE
feat: add kmp-lsp

### DIFF
--- a/packages/kmp-lsp/package.yaml
+++ b/packages/kmp-lsp/package.yaml
@@ -1,0 +1,38 @@
+---
+name: kmp-lsp
+description: Kotlin Multiplatform Language Server
+homepage: https://github.com/Hessesian/kmp-lsp
+licenses:
+  - Apache-2.0
+languages:
+  - Kotlin
+  - Java
+  - Swift
+categories:
+  - LSP
+
+source:
+  id: pkg:github/Hessesian/kmp-lsp@v0.21.0
+  asset:
+    - target: darwin_x64
+      file: kmp-lsp-darwin-x86_64.tar.gz
+      bin: kmp-lsp
+    - target: darwin_arm64
+      file: kmp-lsp-darwin-aarch64.tar.gz
+      bin: kmp-lsp
+    - target: linux_x64_gnu
+      file: kmp-lsp-linux-x86_64.tar.gz
+      bin: kmp-lsp
+    - target: linux_arm64_gnu
+      file: kmp-lsp-linux-aarch64.tar.gz
+      bin: kmp-lsp
+    - target: win_x64
+      file: kmp-lsp-windows-x86_64.zip
+      bin: kmp-lsp-windows-x86_64.exe
+    - target: win_arm64
+      file: kmp-lsp-windows-aarch64.zip
+      bin: kmp-lsp-windows-aarch64.exe
+
+bin:
+  kmp-lsp: "{{source.asset.bin}}"
+


### PR DESCRIPTION
## Summary

Adds `kmp-lsp` — the Kotlin Multiplatform Language Server (https://github.com/Hessesian/kmp-lsp), distinct from the existing JetBrains `kotlin-lsp`. Users can choose between the two.

- License: Apache-2.0
- Languages: Kotlin
- Pre-built binaries for darwin x64/arm64, linux x64/arm64 (GNU), win x64/arm64
- 100+ GitHub stars (eligibility criteria met)

## Test plan

- [ ] `MasonInstall kmp-lsp` on linux_x64_gnu
- [ ] `MasonInstall kmp-lsp` on darwin_arm64
- [ ] `MasonInstall --target=win_x64 kmp-lsp` (soft emulation)