### PR TITLE
bump(pgformatter): bumps to latest 5.10

### DIFF
--- a/packages/pgformatter/package.yaml
+++ b/packages/pgformatter/package.yaml
@@ -12,7 +12,7 @@ categories:
 
 source:
   # renovate:datasource=github-tags
-  id: pkg:github/darold/pgformatter@v5.9
+  id: pkg:github/darold/pgformatter@v5.10
   build:
     run: ""
 


### PR DESCRIPTION
### Describe your changes
Bumps pg formatter to latest

see: https://github.com/darold/pgFormatter/releases

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [ ] I have successfully tested installation of the package.
- [ ] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
