### PR TITLE
feat(packages): add holocron-lsp

### DIFF
--- a/packages/holocron-lsp/package.yaml
+++ b/packages/holocron-lsp/package.yaml
@@ -1,0 +1,31 @@
+name: holocron-lsp
+description: LSP server for Holocron — a declarative schema and query compiler that type-checks SQL queries against a YAML rulebook with rich rustc-style diagnostics.
+homepage: https://github.com/extinctCoder/holocron
+licenses:
+  - MPL-2.0
+languages:
+  - YAML
+categories:
+  - LSP
+
+source:
+  id: pkg:github/extinctCoder/holocron@v0.3.0
+  asset:
+    - target: darwin_x64
+      file: holocron-v{{ version }}-x86_64-apple-darwin.tar.gz
+      bin: holocron-lsp
+    - target: darwin_arm64
+      file: holocron-v{{ version }}-aarch64-apple-darwin.tar.gz
+      bin: holocron-lsp
+    - target: linux_x64_gnu
+      file: holocron-v{{ version }}-x86_64-unknown-linux-gnu.tar.gz
+      bin: holocron-lsp
+    - target: linux_arm64_gnu
+      file: holocron-v{{ version }}-aarch64-unknown-linux-gnu.tar.gz
+      bin: holocron-lsp
+    - target: win_x64
+      file: holocron-v{{ version }}-x86_64-pc-windows-msvc.zip
+      bin: holocron-lsp.exe
+
+bin:
+  holocron-lsp: "{{ source.asset.bin }}"


### PR DESCRIPTION
### Describe your changes
                      
Adds `holocron-lsp` — an LSP server for [Holocron](https://github.com/extinctCoder/holocron), a declarative schema & query compiler that type-checks SQL queries against a YAML rulebook with rustc-style diagnostics. Publishes live diagnostics for schema errors (unknown columns, duplicate aliases, unknown types, etc.) pointing at the exact YAML token.

Activates on `*.holocron.yaml` files. Stdio LSP, no special transport.

### Issue ticket number and link

N/A
  
### Evidence on requirement fulfillment (new packages only)

- Open-source, MPL-2.0: https://github.com/extinctCoder/holocron/blob/main/LICENSE
- Stable release: https://github.com/extinctCoder/holocron/releases/tag/v0.3.0
- Published on crates.io: https://crates.io/crates/holocron/0.3.0
- Cross-platform prebuilt binaries attached to the release for every declared target (darwin x64/arm64, linux x64/arm64 gnu, win x64).
- Stdio LSP (standard JSON-RPC over stdin/stdout).
- Homepage & docs: README includes install + editor integration sections.

### Checklist before requesting a review

- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`. _(Not yet in nvim-lspconfig — separate PR planned.)_
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots

N/A