### PR TITLE
bump(ktfmt): update to v0.64

### DIFF
--- a/packages/ktfmt/package.yaml
+++ b/packages/ktfmt/package.yaml
@@ -10,7 +10,7 @@ categories:
   - Formatter
 
 source:
-  id: pkg:github/facebook/ktfmt@v0.61
+  id: pkg:github/facebook/ktfmt@v0.64
   asset:
     file: ktfmt-{{ version | strip_prefix "v" }}-with-dependencies.jar
 


### PR DESCRIPTION
### Describe your changes
Latest release of ktfmt is v0.64, so we need to bump the version in the registry.

### Issue ticket number and link

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
