### PR TITLE
fix(jdtls): fix download path for jdtls and update to version 1.59.0

### DIFF
--- a/packages/jdtls/package.yaml
+++ b/packages/jdtls/package.yaml
@@ -11,21 +11,21 @@ categories:
 
 source:
   # renovate:datasource=github-tags
-  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.58.0
+  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.59.0
   download:
     - target: [darwin_x64, darwin_arm64]
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202604151538.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{{ version | strip_prefix "v" }}-202605111312.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_mac/
     - target: linux
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202604151538.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{{ version | strip_prefix "v" }}-202605111312.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_linux/
     - target: win
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/milestones/{{ version | strip_prefix "v" }}/jdt-language-server-{{ version | strip_prefix "v" }}-202604151538.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{{ version | strip_prefix "v" }}-202605111312.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_win/
 


### PR DESCRIPTION
Related failing PR - https://github.com/mason-org/mason-registry/pull/15706

Replaced the milestones download path with snapshots and updated the build timestamp, as the original URLs pointed to non-existent or stale artifacts.

https://download.eclipse.org/jdtls/snapshots/jdt-language-server-1.59.0-202605111312.tar.gz

https://download.eclipse.org/jdtls/milestones/1.59.0/jdt-language-server-1.59.0-202605111312.tar.gz

### Describe your changes
Replaced the milestones download path with snapshots and updated the build timestamp, as the original URLs pointed to non-existent or stale artifacts.

### Issue ticket number and link


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
Before fix:
<img width="852" height="95" alt="image" src="https://github.com/user-attachments/assets/460a6114-9a85-4878-ac02-b3853297ee25" />

<img width="1416" height="346" alt="image" src="https://github.com/user-attachments/assets/01198466-ba97-4551-844a-df9a3708d92f" />

After fix:
<img width="1400" height="242" alt="image" src="https://github.com/user-attachments/assets/cd06524f-3520-44f1-a26b-ef067bc10af9" />

<img width="1404" height="448" alt="image" src="https://github.com/user-attachments/assets/68109cfe-8d83-498e-8340-aabade601098" />


