### PR TITLE
updating kotlin-lsp base url

### DIFF
--- a/packages/kotlin-lsp/package.yaml
+++ b/packages/kotlin-lsp/package.yaml
@@ -12,31 +12,31 @@ categories:
 source:
   # renovate:versioning=regex:^kotlin-lsp/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
   # renovate:datasource=github-releases
-  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v262.7569.0
+  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v262.8190.0
   download:
     - target: darwin_x64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.sit
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/language-server/kotlin-server/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.sit
       bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: darwin_arm64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.sit
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/language-server/kotlin-server/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.sit
       bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: linux_x64
       files:
-        kotlin-lsp.tar.gz: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.tar.gz
+        kotlin-lsp.tar.gz: https://download-cdn.jetbrains.com/language-server/kotlin-server/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.tar.gz
       bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: linux_arm64
       files:
-        kotlin-lsp.tar.gz: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.tar.gz
+        kotlin-lsp.tar.gz: https://download-cdn.jetbrains.com/language-server/kotlin-server/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.tar.gz
       bin: kotlin-server-{{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: win_x64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.win.zip
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/language-server/kotlin-server/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.win.zip
       bin: bin/intellij-server.exe
     - target: win_arm64
       files:
-        kotlin-lsp.zip: https://download-cdn.jetbrains.com/kotlin-lsp/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.win.zip
+        kotlin-lsp.zip: https://download-cdn.jetbrains.com/language-server/kotlin-server/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.win.zip
       bin: bin/intellij-server.exe
 
 bin:


### PR DESCRIPTION
### Describe your changes
- updated kotlin-lsp to v262.8190.0
- changed base url
- updated from https://download-cdn.jetbrains.com/kotlin-lsp to https://download-cdn.jetbrains.com/language-server/kotlin-server

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
