### PR TITLE
chore(jdtls): bump to 1.60.0

### DIFF
--- a/packages/jdtls/package.yaml
+++ b/packages/jdtls/package.yaml
@@ -11,21 +11,21 @@ categories:
 
 source:
   # renovate:datasource=github-tags
-  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.59.0
+  id: pkg:generic/eclipse/eclipse.jdt.ls@v1.60.0
   download:
     - target: [darwin_x64, darwin_arm64]
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{{ version | strip_prefix "v" }}-202605111312.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{{ version | strip_prefix "v" }}-202606262232.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_mac/
     - target: linux
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{{ version | strip_prefix "v" }}-202605111312.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{{ version | strip_prefix "v" }}-202606262232.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_linux/
     - target: win
       files:
-        jdtls.tar.gz: https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{{ version | strip_prefix "v" }}-202605111312.tar.gz
+        jdtls.tar.gz: https://download.eclipse.org/jdtls/snapshots/jdt-language-server-{{ version | strip_prefix "v" }}-202606262232.tar.gz
         lombok.jar: https://projectlombok.org/downloads/lombok.jar
       config: config_win/
 
@@ -38,7 +38,7 @@ bin:
 share:
   jdtls/lombok.jar: lombok.jar
   jdtls/plugins/: plugins/
-  jdtls/plugins/org.eclipse.equinox.launcher.jar: plugins/org.eclipse.equinox.launcher_1.7.100.v20251111-0406.jar
+  jdtls/plugins/org.eclipse.equinox.launcher.jar: plugins/org.eclipse.equinox.launcher_1.7.200.v20260619-2039.jar
   jdtls/config/: "{{source.download.config}}"
 
 neovim:


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
Upgrading jdtls
### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
<img width="1716" height="339" alt="image" src="https://github.com/user-attachments/assets/6412aa15-b30e-4eee-a569-22b64b54549c" />
