### PR TITLE
Bump latexindent

### DIFF
--- a/packages/latexindent/package.yaml
+++ b/packages/latexindent/package.yaml
@@ -12,7 +12,7 @@ categories:
   - Formatter
 
 source:
-  id: pkg:github/cmhughes/latexindent.pl@V3.24.4
+  id: pkg:github/cmhughes/latexindent.pl@V4.0.2
   asset:
     - target: [darwin_x64, darwin_arm64]
       file: latexindent-macos


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

Bump `latexindent` to the latest version (`v4.0.2`). The main interest is that `v4` offers a significant performance improvement over `v3`, which makes `latexindent` competitive with `tex-fmt`.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
A Screenshot of `mason` with `latexindent` v4.0.2 installed. Formatting works as expected.
<img width="1559" height="940" alt="Mason-latexindent-v4" src="https://github.com/user-attachments/assets/5e8dfe59-f4d3-40ff-83c6-d4cf3f9f4081" />
