### PR TITLE
feat: Add Claude Agent ACP adapter

### DIFF
--- a/packages/claude-agent-acp/package.yaml
+++ b/packages/claude-agent-acp/package.yaml
@@ -1,0 +1,12 @@
+---
+name: claude-agent-acp
+description: ACP adapter for the Claude Agent SDK
+homepage: https://github.com/agentclientprotocol/claude-agent-acp
+licenses:
+  - Apache-2.0
+languages: []
+categories: []
+source:
+  id: pkg:npm/@agentclientprotocol/claude-agent-acp@0.55.0
+bin:
+  claude-agent-acp: npm:claude-agent-acp


### PR DESCRIPTION
### Describe your changes
Adds a package spec for [claude-agent-acp](https://github.com/agentclientprotocol/claude-agent-acp), an Agent Client Protocol Adapter for the Claude Agent SDK. This enables driving Claude Code via ACP-client plugins like 
- [codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) 
- [avante.nvim](https://github.com/yetone/avante.nvim)
- [agentic.nvim](https://github.com/carlos-algms/agentic.nvim)

### Issue ticket number and link
N/A

### Evidence on requirement fulfillment (new packages only)
- At least 100 stars on GitHub: https://github.com/agentclientprotocol/claude-agent-acp (>2K stars)

### Checklist before requesting a review
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      
### Screenshots
N/A