### PR TITLE
feat(protols): use  binaries from GitHub releases

### DIFF
--- a/packages/protols/package.yaml
+++ b/packages/protols/package.yaml
@@ -10,10 +10,25 @@ categories:
   - LSP
 
 source:
-  id: pkg:cargo/protols@0.14.1
-
+  id: pkg:github/coder3101/protols@0.14.1
+  asset:
+    - target: darwin_arm64
+      file: protols-aarch64-apple-darwin.tar.gz
+      bin: protols
+    - target: darwin_x64
+      file: protols-x86_64-apple-darwin.tar.gz
+      bin: protols
+    - target: linux_arm64
+      file: protols-aarch64-unknown-linux-gnu.tar.gz
+      bin: protols
+    - target: linux_x64
+      file: protols-x86_64-unknown-linux-gnu.tar.gz
+      bin: protols
+    - target: win_x64
+      file: protols-x86_64-pc-windows-msvc.zip
+      bin: protols.exe
 bin:
-  protols: cargo:protols
+  protols: "{{source.asset.bin}}"
 
 neovim:
   lspconfig: protols


### PR DESCRIPTION
### Describe your changes

This change replaces cargo compile with downloading prebuilt binaries from GitHub releases.
 
### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots / Samples

Being able to install protols without cargo

```
[0]-[mason-registry(main)]-λ ~/.local/share/nvim/mason/bin/protols --version
protols 0.14.1
fallback include path: not set
[0]-[mason-registry(main)]-λ which cargo
cargo not found
```

LSP working in neovim:

<img width="475" height="160" alt="image" src="https://github.com/user-attachments/assets/6522806a-e0aa-4f10-a5f2-49a140c6af91" />

<!-- Leave empty if not applicable -->
