### PR TITLE
feat: terragrunt-ls

### DIFF
--- a/packages/terragrunt-ls/package.yaml
+++ b/packages/terragrunt-ls/package.yaml
@@ -1,0 +1,38 @@
+---
+name: terragrunt-ls
+description: Language server for Terragrunt configuration files.
+homepage: https://github.com/gruntwork-io/terragrunt-ls
+licenses:
+  - MPL-2.0
+languages:
+  - HCL
+categories:
+  - LSP
+
+source:
+  id: pkg:github/gruntwork-io/terragrunt-ls@v0.0.6
+  asset:
+    - target: darwin_x64
+      file: terragrunt-ls_darwin_amd64.tar.gz
+      bin: terragrunt-ls
+    - target: darwin_arm64
+      file: terragrunt-ls_darwin_arm64.tar.gz
+      bin: terragrunt-ls
+    - target: linux_x64_gnu
+      file: terragrunt-ls_linux_amd64.tar.gz
+      bin: terragrunt-ls
+    - target: linux_arm64_gnu
+      file: terragrunt-ls_linux_arm64.tar.gz
+      bin: terragrunt-ls
+    - target: win_x64
+      file: terragrunt-ls_windows_amd64.zip
+      bin: terragrunt-ls.exe
+    - target: win_arm64
+      file: terragrunt-ls_windows_arm64.zip
+      bin: terragrunt-ls.exe
+
+bin:
+  terragrunt-ls: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: terragrunt_ls


### PR DESCRIPTION
### Describe your changes

Adds `terragrunt-ls`, a language server for Terragrunt configuration files (`terragrunt.hcl`, `terragrunt.stack.hcl`, `terragrunt.values.hcl`).

### Evidence on requirement fulfillment (new packages only)

Approved at nvim-lspconfig: https://github.com/neovim/nvim-lspconfig/pull/4473

### Checklist before requesting a review

- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots

Tested with a local registry. Was able to install, started on the appropriate files, generally worked as expected.

<img width="976" height="342" alt="image" src="https://github.com/user-attachments/assets/43d1d66e-9ae4-491f-bee5-d9c2866e1766" />

<img width="1376" height="218" alt="image" src="https://github.com/user-attachments/assets/35db6f61-30e2-489a-bb8d-02e2e2943635" />


