### PR TITLE
(bump) update java-test to 0.46

### DIFF
--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -23,7 +23,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:openvsx/vscjava/vscode-java-test@0.45.0
+  id: pkg:openvsx/vscjava/vscode-java-test@0.46.0
   download:
     file: vscjava.vscode-java-test-{{version}}.vsix
     plugin_version: 0.43.1


### PR DESCRIPTION
update java test version to pkg:openvsx/vscjava/vscode-java-test@0.46.0
https://github.com/microsoft/vscode-java-test/releases/tag/0.46.0