### PR TITLE
feat: add pyfun

### DIFF
--- a/packages/pyfun/package.yaml
+++ b/packages/pyfun/package.yaml
@@ -1,0 +1,22 @@
+---
+name: pyfun
+description: |
+  Pyfun is an F#-inspired, functional-first language for the Python ecosystem that compiles to readable Python.
+  The pyfun binary provides both the compiler and the language server.
+homepage: https://github.com/simontreanor/Pyfun
+licenses:
+  - Apache-2.0
+languages:
+  - Pyfun
+categories:
+  - LSP
+  - Compiler
+
+source:
+  id: pkg:pypi/pyfun-lang@0.0.9
+
+bin:
+  pyfun: pypi:pyfun
+
+neovim:
+  lspconfig: pyfun


### PR DESCRIPTION
### Describe your changes

Adds `packages/pyfun/package.yaml` for [Pyfun](https://github.com/simontreanor/Pyfun), an F#-inspired, functional-first language that compiles to readable Python. The `pyfun` binary bundles the compiler and the language server (`pyfun lsp`) and is published on PyPI as `pyfun-lang` (`pip install pyfun-lang`, currently 0.0.9).

### Issue ticket number and link

N/A

### Evidence on requirement fulfillment (new packages only)

nvim-lspconfig PR (pending review): https://github.com/neovim/nvim-lspconfig/pull/4476

### Checklist before requesting a review

- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)