### PR TITLE
feat: Add Codex ACP adapter

### DIFF
--- a/packages/codex-acp/package.yaml
+++ b/packages/codex-acp/package.yaml
@@ -1,0 +1,12 @@
+---
+name: codex-acp
+description: ACP adapter for Codex CLI
+homepage: https://github.com/agentclientprotocol/codex-acp
+licenses:
+  - Apache-2.0
+languages: []
+categories: []
+source:
+  id: pkg:npm/@agentclientprotocol/codex-acp@1.1.2
+bin:
+  codex-acp: npm:codex-acp


### PR DESCRIPTION
### Describe your changes
Adds a package spec for [codex-acp](https://github.com/agentclientprotocol/codex-acp), an Agent Client Protocol Adapter for Codex CLI. This enables driving Codex  via ACP-client plugins like 
- [codecompanion.nvim](https://github.com/olimorris/codecompanion.nvim) 
- [avante.nvim](https://github.com/yetone/avante.nvim)
- [agentic.nvim](https://github.com/carlos-algms/agentic.nvim)


### Issue ticket number and link
N/A

### Evidence on requirement fulfillment (new packages only)
- At least 100 stars on GitHub: https://github.com/agentclientprotocol/codex-acp (130 stars)

### Checklist before requesting a review
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
N/A