### PR TITLE
fix(vuels): pin typescript to 6.0.3, since 7.x is not compatible with vue yet

### DIFF
--- a/packages/vue-language-server/package.yaml
+++ b/packages/vue-language-server/package.yaml
@@ -12,6 +12,7 @@ categories:
 source:
   id: pkg:npm/%40vue/language-server@3.3.7
   extra_packages:
+    # vue_ls doesn't support typescript v7, yet. See https://github.com/mason-org/mason-registry/issues/15934
     - "typescript@6.0.3"
     - "@vue/typescript-plugin"
 schemas:

--- a/packages/vue-language-server/package.yaml
+++ b/packages/vue-language-server/package.yaml
@@ -12,7 +12,7 @@ categories:
 source:
   id: pkg:npm/%40vue/language-server@3.3.7
   extra_packages:
-    - typescript
+    - "typescript@6.0.3"
     - "@vue/typescript-plugin"
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/vuejs/language-tools/v{{version}}/extensions/vscode/package.json


### PR DESCRIPTION
### Describe your changes
Typescript 7.x is not compatible with the vue language server.

### Issue ticket number and link
#15934 


### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
