### PR TITLE
feat: add prolog (swi-prolog) language server

### DIFF
--- a/packages/prolog-lsp/package.yaml
+++ b/packages/prolog-lsp/package.yaml
@@ -1,0 +1,39 @@
+---
+name: prolog-lsp
+description: |
+  Language Server Protocol server for SWI-Prolog. Provides completion, hover, go-to-definition, find references,
+  document highlighting, formatting, and diagnostics. Requires SWI-Prolog (swipl) to be installed and available on PATH.
+homepage: https://github.com/jamesnvc/lsp_server
+licenses:
+  - BSD-2-Clause
+languages:
+  - Prolog
+categories:
+  - LSP
+
+source:
+  # renovate:datasource=github-tags
+  id: pkg:github/jamesnvc/lsp_server@v3.17.0
+  supported_platforms:
+    - darwin
+    - linux
+  build:
+    - target: unix
+      run: |
+        cat > prolog-lsp <<EOF
+        #!/usr/bin/env sh
+        exec swipl \
+          -p library="$PWD/prolog" \
+          -g "use_module(library(lsp_server))." \
+          -g "lsp_server:main" \
+          -t halt \
+          -- "\$@"
+        EOF
+        chmod +x prolog-lsp
+      bin: prolog-lsp
+
+bin:
+  prolog-lsp: "{{source.build.bin}}"
+
+neovim:
+  lspconfig: prolog_ls


### PR DESCRIPTION
### Describe your changes
Adding support for Prolog language server

### Issue ticket number and link

### Evidence on requirement fulfillment (new packages only)
- 100+ GitHub stars (128 stars): https://github.com/jamesnvc/lsp_server 
- Approved at nvim-lspconfig (prolog_ls): https://github.com/neovim/nvim-lspconfig/blob/master/lsp/prolog_ls.lua 

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
On a fresh Nvim install/config:

`:MasonInstall prolog-lsp` yields:
<img width="1095" height="278" alt="Screenshot 2026-07-16 at 12 45 00 PM" src="https://github.com/user-attachments/assets/fe8023c7-06db-46e7-ba3c-35c93bbba933" />

Hover yields:
<img width="843" height="508" alt="Screenshot 2026-07-16 at 12 45 52 PM" src="https://github.com/user-attachments/assets/ebaca14e-e660-44f6-ae8e-4ee781d1bcd3" />

Go to definition on `greeting(x)` in `main` works, yields:
<img width="509" height="119" alt="Screenshot 2026-07-16 at 12 49 19 PM" src="https://github.com/user-attachments/assets/dbb5a5b2-5ec9-426a-9dbc-8e13aa8dbbed" />
