### PR TITLE
fix(ts_ls): pin the version of typescript to 6.0.3, fixing the tsserver.path error

### DIFF
--- a/packages/typescript-language-server/package.yaml
+++ b/packages/typescript-language-server/package.yaml
@@ -13,7 +13,9 @@ categories:
 source:
   id: pkg:npm/typescript-language-server@5.3.0
   extra_packages:
-    - typescript
+    # The latest TS 7 removed lib/tsserver.js which is required by ts_ls.
+    # See: https://github.com/mason-org/mason-registry/issues/15985
+    - "typescript@6.0.3"
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/microsoft/vscode/main/extensions/typescript-language-features/package.json


### PR DESCRIPTION
### Describe your changes
Pinned the version of typescript to 6.0.3 since the new typescript 7 removes the lib/tsserver.js  which produces the tsserver.path error in typescript-language-server.

### Issue ticket number and link
#15985

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
