### PR TITLE
feat: add shuck

### DIFF
--- a/packages/shuck/package.yaml
+++ b/packages/shuck/package.yaml
@@ -8,6 +8,7 @@ languages:
   - Bash
   - Zsh
   - Sh
+  - Mksh
 categories:
   - LSP
   - Linter

--- a/packages/shuck/package.yaml
+++ b/packages/shuck/package.yaml
@@ -1,0 +1,42 @@
+---
+name: shuck
+description: A lightning fast shell linter, formatter, and LSP server for bash, zsh, posix, and mksh dialects.
+homepage: https://ewhauser.github.io/shuck/
+licenses:
+  - MIT
+languages:
+  - Bash
+  - Zsh
+  - Sh
+categories:
+  - LSP
+  - Linter
+  - Formatter
+
+source:
+  id: pkg:github/ewhauser/shuck@v0.0.45
+  asset:
+    - target: darwin_arm64
+      file: shuck-cli-aarch64-apple-darwin.tar.xz
+      bin: shuck-cli-aarch64-apple-darwin/shuck
+    - target: linux_arm64_gnu
+      file: shuck-cli-aarch64-unknown-linux-gnu.tar.xz
+      bin: shuck-cli-aarch64-unknown-linux-gnu/shuck
+    - target: linux_arm64_musl
+      file: shuck-cli-aarch64-unknown-linux-musl.tar.xz
+      bin: shuck-cli-aarch64-unknown-linux-musl/shuck
+    - target: linux_x64_gnu
+      file: shuck-cli-x86_64-unknown-linux-gnu.tar.xz
+      bin: shuck-cli-x86_64-unknown-linux-gnu/shuck
+    - target: linux_x64_musl
+      file: shuck-cli-x86_64-unknown-linux-musl.tar.xz
+      bin: shuck-cli-x86_64-unknown-linux-musl/shuck
+    - target: win_x64
+      file: shuck-cli-x86_64-pc-windows-msvc.zip
+      bin: shuck.exe
+
+bin:
+  shuck: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: shuck


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

Add [shuck](https://github.com/ewhauser/shuck) — a lightning fast shell linter, formatter, and LSP server for bash, zsh, posix, and mksh dialects, written in Rust.

The package uses prebuilt GitHub release assets for 6 targets (darwin_arm64, linux_x64/arm64 with gnu and musl variants, win_x64). Upstream does not publish darwin_x64 binaries.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

shuck is approved in nvim-lspconfig: https://github.com/neovim/nvim-lspconfig/blob/master/lsp/shuck.lua

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
