### PR TITLE
fix(astro): pin typescript to v6

### DIFF
--- a/packages/astro-language-server/package.yaml
+++ b/packages/astro-language-server/package.yaml
@@ -13,7 +13,7 @@ source:
   id: pkg:npm/%40astrojs/language-server@2.16.13
   extra_packages:
     # Not support typescript v7 yet.
-    # See https://github.com/withastro/astro/issues/17268
+    # See https://github.com/withastro/roadmap/discussions/1321
     - "typescript@6.0.3"
     - "@astrojs/ts-plugin"
 

--- a/packages/astro-language-server/package.yaml
+++ b/packages/astro-language-server/package.yaml
@@ -12,7 +12,9 @@ categories:
 source:
   id: pkg:npm/%40astrojs/language-server@2.16.13
   extra_packages:
-    - typescript
+    # Not support typescript v7 yet.
+    # See https://github.com/withastro/astro/issues/17268
+    - "typescript@6.0.3"
     - "@astrojs/ts-plugin"
 
 bin:


### PR DESCRIPTION
### Describe your changes

Pinned TypeScript version to v6 because TypeScript v7 is not supported by astro-language-server.

### Checklist before requesting a review
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
<!-- Leave empty if not applicable -->
