### PR TITLE
fix(ruff): use github releases instead of pypi

### DIFF
--- a/packages/ruff/package.yaml
+++ b/packages/ruff/package.yaml
@@ -12,10 +12,44 @@ categories:
   - LSP
 
 source:
-  id: pkg:pypi/ruff@0.16.1
+  id: pkg:github/astral-sh/ruff@0.16.1
+  asset:
+    - target: darwin_x64
+      file: ruff-x86_64-apple-darwin.tar.gz
+      bin: ruff-x86_64-apple-darwin/ruff
+    - target: darwin_arm64
+      file: ruff-aarch64-apple-darwin.tar.gz
+      bin: ruff-aarch64-apple-darwin/ruff
+    - target: linux_x64
+      file: ruff-x86_64-unknown-linux-musl.tar.gz
+      bin: ruff-x86_64-unknown-linux-musl/ruff
+    - target: linux_arm64
+      file: ruff-aarch64-unknown-linux-gnu.tar.gz
+      bin: ruff-aarch64-unknown-linux-gnu/ruff
+    - target: linux_x64_musl
+      file: ruff-x86_64-unknown-linux-musl.tar.gz
+      bin: ruff-x86_64-unknown-linux-musl/ruff
+    - target: linux_arm64_musl
+      file: ruff-aarch64-unknown-linux-musl.tar.gz
+      bin: ruff-aarch64-unknown-linux-musl/ruff
+    - target: linux_x86
+      file: ruff-i686-unknown-linux-gnu.tar.gz
+      bin: ruff-i686-unknown-linux-gnu/ruff
+    - target: linux_armv7_gnu
+      file: ruff-armv7-unknown-linux-gnueabihf.tar.gz
+      bin: ruff-armv7-unknown-linux-gnueabihf/ruff
+    - target: win_x64
+      file: ruff-x86_64-pc-windows-msvc.zip
+      bin: ruff.exe
+    - target: win_arm64
+      file: ruff-aarch64-pc-windows-msvc.zip
+      bin: ruff.exe
+    - target: win_x86
+      file: ruff-i686-pc-windows-msvc.zip
+      bin: ruff.exe
 
 bin:
-  ruff: pypi:ruff
+  ruff: "{{source.asset.bin}}"
 
 neovim:
   lspconfig: ruff


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->

`ruff` is a Python-independent binary. The current installation method requires a Python runtime, leading to failures on systems without `python3-venv`.

This change switches to pre-built binaries from GitHub Releases, eliminating the Python dependency.

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
