### PR TITLE
feat(laravel_lsp): add laravel/lsp package

### DIFF
--- a/packages/laravel_lsp/package.yaml
+++ b/packages/laravel_lsp/package.yaml
@@ -1,0 +1,20 @@
+---
+name: laravel_lsp
+description: The Laravel language server.
+homepage: https://github.com/laravel/lsp
+licenses:
+  - MIT
+languages:
+  - PHP
+  - Blade
+categories:
+  - LSP
+
+source:
+  id: pkg:composer/laravel/lsp@v0.0.29
+
+bin:
+  laravel-lsp: composer:laravel-lsp
+
+schemas:
+  lsp: vscode:https://raw.githubusercontent.com/laravel/vs-code-extension/main/package.json

--- a/packages/laravel_lsp/package.yaml
+++ b/packages/laravel_lsp/package.yaml
@@ -11,10 +11,24 @@ categories:
   - LSP
 
 source:
-  id: pkg:composer/laravel/lsp@v0.0.29
+  id: pkg:github/laravel/lsp@v0.0.29
+  asset:
+    - target: darwin_arm64
+      file: server-{{version}}-arm64-darwin
+    - target: darwin_x64
+      file: server-{{version}}-x64-darwin
+    - target: linux_arm64
+      file: server-{{version}}-arm64-linux
+    - target: linux_x64
+      file: server-{{version}}-x64-linux
+    - target: win_x64
+      file: server-{{version}}-x64-win32.exe
 
 bin:
-  laravel-lsp: composer:laravel-lsp
+  laravel-lsp: "{{source.asset.file}}"
 
 schemas:
   lsp: vscode:https://raw.githubusercontent.com/laravel/vs-code-extension/main/package.json
+
+neovim:
+  lspconfig: laravel_lsp

--- a/packages/laravel_lsp/package.yaml
+++ b/packages/laravel_lsp/package.yaml
@@ -11,7 +11,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:github/laravel/lsp@v0.0.29
+  id: pkg:github/laravel/lsp@v0.0.31
   asset:
     - target: darwin_arm64
       file: server-{{version}}-arm64-darwin


### PR DESCRIPTION
Adds the official Laravel language server (`composer global require laravel/lsp`).

- Homepage: https://github.com/laravel/lsp
- License: MIT
- Languages: PHP, Blade
- Categories: LSP

Verified locally: `:MasonInstall laravel_lsp` succeeded and `laravel-lsp --version` outputs `Laravel LSP v0.0.29`.