### PR TITLE
feat(luafmt): add package entry

### DIFF
--- a/packages/luafmt/package.yaml
+++ b/packages/luafmt/package.yaml
@@ -1,0 +1,44 @@
+---
+name: luafmt
+description: A command-line tool for formatting Lua code.
+homepage: https://github.com/EmmyLuaLs/emmylua-analyzer-rust/tree/main/crates/emmylua_formatter
+licenses:
+  - MIT
+languages:
+  - Lua
+categories:
+  - Formatter
+
+source:
+  id: pkg:github/EmmyLuaLs/emmylua-analyzer-rust@0.25.0
+  asset:
+    - target: darwin_arm64
+      file: luafmt-darwin-arm64.tar.gz
+      bin: luafmt
+    - target: darwin_x64
+      file: luafmt-darwin-x64.tar.gz
+      bin: luafmt
+    - target: linux_arm64_gnu
+      file: luafmt-linux-aarch64-glibc.2.17.tar.gz
+      bin: luafmt
+    - target: linux_x64_gnu
+      file: luafmt-linux-x64-glibc.2.17.tar.gz
+      bin: luafmt
+    - target: linux_x64_musl
+      file: luafmt-linux-musl.tar.gz
+      bin: luafmt
+    - target: linux_x64
+      file: luafmt-linux-musl.tar.gz
+      bin: luafmt
+    - target: win_arm64
+      file: luafmt-win32-arm64.zip
+      bin: luafmt.exe
+    - target: win_x86
+      file: luafmt-win32-ia32.zip
+      bin: luafmt.exe
+    - target: win_x64
+      file: luafmt-win32-x64.zip
+      bin: luafmt.exe
+
+bin:
+  luafmt: "{{source.asset.bin}}"


### PR DESCRIPTION
### Describe your changes

Add the standalone `luafmt` formatter from EmmyLuaLs, using the v0.25.0 release assets for supported macOS, Linux, and Windows targets.

The GNU x64 target uses the glibc 2.17 build for broader compatibility, while the generic Linux x64 fallback uses the musl build.

### Issue ticket number and link

### Evidence on requirement fulfillment (new packages only)

https://github.com/EmmyLuaLs/emmylua-analyzer-rust

### Checklist before requesting a review

- [x] Not applicable: luafmt is a standalone formatter, not an LSP server, so the nvim-lspconfig requirement does not apply.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
