### PR TITLE
fix(kotlin-lsp): correct linux_arm64 bin path template

### DIFF
--- a/packages/kotlin-lsp/package.yaml
+++ b/packages/kotlin-lsp/package.yaml
@@ -29,7 +29,7 @@ source:
     - target: linux_arm64
       files:
         kotlin-lsp.tar.gz: https://download-cdn.jetbrains.com/language-server/kotlin-server/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}-aarch64.tar.gz
-      bin: kotlin-server-{{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
+      bin: kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}/bin/intellij-server
     - target: win_x64
       files:
         kotlin-lsp.zip: https://download-cdn.jetbrains.com/language-server/kotlin-server/{{ version | strip_prefix "kotlin-lsp/v" }}/kotlin-server-{{ version | strip_prefix "kotlin-lsp/v" }}.win.zip


### PR DESCRIPTION
### Describe your changes

Fixes the linux_arm64 bin path for kotlin-lsp, which used {{{ instead of {{, breaking template parsing
for that target.

### Issue ticket number and link

N/A

### Evidence on requirement fulfillment (new packages only)

N/A — bug fix to an existing package, not a new package.

### Checklist before requesting a review

- [ ] If the package is available at nvim-lspconfig, I also added the respective name to
neovim.lspconfig.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

Screenshots

<img width="529" height="96" alt="Screenshot 2026-08-07 at 16 49 43" src="https://github.com/user-attachments/assets/8ed5530d-2b5f-4442-8303-83741565166c" />

<img width="671" height="196" alt="Screenshot 2026-08-07 at 16 50 06" src="https://github.com/user-attachments/assets/a2ab5a67-f302-4f4e-a941-18900c319065" />