### PR TITLE
Feature/tsc

### DIFF
--- a/packages/tsc/package.yaml
+++ b/packages/tsc/package.yaml
@@ -1,0 +1,24 @@
+---
+name: tsc
+description: |
+  TypeScript is a language for application-scale JavaScript. TypeScript adds optional types to JavaScript that support
+  tools for large-scale JavaScript applications for any browser, for any host, on any OS. Includes a built-in language
+  server with Language Server Protocol support.
+homepage: https://www.typescriptlang.org/
+licenses:
+  - Apache-2.0
+languages:
+  - TypeScript
+  - JavaScript
+categories:
+  - Compiler
+  - LSP
+
+source:
+  id: pkg:npm/typescript@7.0.2
+
+bin:
+  tsc: npm:tsc
+
+neovim:
+  lspconfig: tsc

--- a/packages/tsgo/package.yaml
+++ b/packages/tsgo/package.yaml
@@ -1,5 +1,8 @@
 ---
 name: tsgo
+deprecation:
+  since: "2026-08-13"
+  message: The native TypeScript compiler preview has been released as TypeScript 7 in the regular typescript package. Use the package `tsc` instead.
 description: |
   Native TypeScript compiler port. Language Server Protocol support with partial
   features including errors, hover, go to definition, references, and signature help.


### PR DESCRIPTION
### Describe your changes
Typescript 7 is a full rewrite in golang, and includes a full language server.

It was recently added to [`nvim-lspconfig`](https://github.com/neovim/nvim-lspconfig/pull/4493), so I think it's time to add it mason :)
I choose the name `tsc` to match `nvim-lspconfig`'s name, an because `typescript-language-server` is already taken.

It supersede tsgo (which was the beta version of TS 7).
I think we shouldn't deprecate `typescript-language-server` because it is still useful for projects that didn't update to TS7 (e.g. projects that use ESLint - which still doesn't support TS7).

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->
https://github.com/neovim/nvim-lspconfig/pull/4493
https://www.npmjs.com/package/typescript

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [X] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [X] I have successfully tested installation of the package.
- [X] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
