### PR TITLE
bump(roslyn-language-server): update to v5.11.0-1.26380.4

### DIFF
--- a/packages/roslyn-language-server/package.yaml
+++ b/packages/roslyn-language-server/package.yaml
@@ -12,7 +12,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:nuget/roslyn-language-server@5.8.0-1.26266.2
+  id: pkg:nuget/roslyn-language-server@5.11.0-1.26380.4
 
 bin:
   roslyn-language-server: nuget:roslyn-language-server


### PR DESCRIPTION
### Describe your changes
Manually bump `roslyn-language-server`'s version to `v5.11.0-1.26380.4` due to `renovate` not detecting new pre-release versions.

### Issue ticket number and link
#15738 

### Evidence on requirement fulfillment (new packages only)
N/A

### Checklist before requesting a review
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots

<img width="1918" height="998" alt="Screenshot 2026-08-15 at 15 41 32" src="https://github.com/user-attachments/assets/97beb3f6-0353-4c20-9c9f-7a93a1396eb9" />