### PR TITLE
bump(sharpdbg): update to v0.1.13

### DIFF
--- a/packages/sharpdbg/package.yaml
+++ b/packages/sharpdbg/package.yaml
@@ -14,7 +14,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:nuget/SharpDbg.Cli@0.1.2
+  id: pkg:nuget/SharpDbg.Cli@0.1.13
 
 bin:
   sharpdbg: nuget:sharpdbg


### PR DESCRIPTION
### Describe your changes
Manually bump `sharpdbg`s version to `v0.1.13` due to `renovate` not detecting new versions.

### Issue ticket number and link
https://github.com/mason-org/mason-registry/issues/15745#issuecomment-5302219158

### Evidence on requirement fulfillment (new packages only)
N/A

### Checklist before requesting a review

- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots

<img width="1916" height="994" alt="Screenshot 2026-08-15 at 15 55 45" src="https://github.com/user-attachments/assets/5a07a2ae-b879-4c2f-ae38-719476f5dea2" />