### PR TITLE
Add support for Symfony LSP

### DIFF
--- a/packages/symfony-lsp/package.yaml
+++ b/packages/symfony-lsp/package.yaml
@@ -1,0 +1,39 @@
+---
+name: symfony-lsp
+description: A language server for Symfony applications.
+homepage: https://github.com/symfony/language-tools
+licenses:
+  - MIT
+languages:
+  - PHP
+  - Twig
+  - YAML
+  - JavaScript
+  - TypeScript
+categories:
+  - LSP
+
+source:
+  id: pkg:github/symfony/language-tools@v0.10.0
+  asset:
+    - target: darwin_arm64
+      file: symfony-lsp-{{version}}-macos-arm64.tar.gz
+      bin: exec:symfony-lsp-{{version}}-macos-arm64/symfony-lsp
+    - target: darwin_x64
+      file: symfony-lsp-{{version}}-macos-x64.tar.gz
+      bin: exec:symfony-lsp-{{version}}-macos-x64/symfony-lsp
+    - target: linux_arm64
+      file: symfony-lsp-{{version}}-linux-arm64.tar.gz
+      bin: exec:symfony-lsp-{{version}}-linux-arm64/symfony-lsp
+    - target: linux_x64
+      file: symfony-lsp-{{version}}-linux-x64.tar.gz
+      bin: exec:symfony-lsp-{{version}}-linux-x64/symfony-lsp
+    - target: win_x64
+      file: symfony-lsp-{{version}}-windows-x64.zip
+      bin: symfony-lsp-{{version}}-windows-x64/symfony-lsp.exe
+
+bin:
+  symfony-lsp: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: symfony_lsp


### PR DESCRIPTION
### Describe your changes

Add the official Symfony Language Tools package for macOS, Linux, and Windows. The package installs the standalone 0.10.0 release, exposes `symfony-lsp`, and maps it to the submitted `symfony_lsp` nvim-lspconfig configuration.

### Issue ticket number and link

None.

### Evidence on requirement fulfillment

Symfony Language Tools is maintained and officially distributed by the Symfony organization: https://github.com/symfony/language-tools

It is also published by the verified Symfony publisher on the Visual Studio Marketplace: https://marketplace.visualstudio.com/items?itemName=symfony.language-tools

### Checklist before requesting a review

- [x] The corresponding `symfony_lsp` nvim-lspconfig configuration has been submitted upstream.
- [x] I successfully installed the package through Mason 2.3.1 from this registry definition.
- [x] I successfully initialized Symfony Language Tools 0.10.0 through Neovim after installation.

The registry schema, language, and license validators pass. All five release assets and executable paths were also verified.

### Screenshots

Not applicable.