### PR TITLE
feat: add ms-terraform-lsp

### DIFF
--- a/packages/ms-terraform-lsp/package.yaml
+++ b/packages/ms-terraform-lsp/package.yaml
@@ -1,0 +1,46 @@
+---
+name: ms-terraform-lsp
+description: |
+  Microsoft Terraform Providers Language Server. Completion, hover documentation and schema validation for the azapi,
+  azurerm and msgraph Terraform providers, and for Azure Verified Modules.
+homepage: https://github.com/Azure/ms-terraform-lsp
+licenses:
+  - MPL-2.0
+languages:
+  - Terraform
+categories:
+  - LSP
+
+source:
+  id: pkg:github/Azure/ms-terraform-lsp@v0.10.0
+  asset:
+    - target: darwin_arm64
+      file: ms-terraform-lsp_{{version}}_darwin_arm64.zip
+      bin: ms-terraform-lsp
+    - target: darwin_x64
+      file: ms-terraform-lsp_{{version}}_darwin_amd64.zip
+      bin: ms-terraform-lsp
+    - target: linux_arm64
+      file: ms-terraform-lsp_{{version}}_linux_arm64.zip
+      bin: ms-terraform-lsp
+    - target: linux_arm
+      file: ms-terraform-lsp_{{version}}_linux_arm.zip
+      bin: ms-terraform-lsp
+    - target: linux_x64
+      file: ms-terraform-lsp_{{version}}_linux_amd64.zip
+      bin: ms-terraform-lsp
+    - target: win_x64
+      file: ms-terraform-lsp_{{version}}_windows_amd64.zip
+      bin: ms-terraform-lsp.exe
+    - target: win_x86
+      file: ms-terraform-lsp_{{version}}_windows_386.zip
+      bin: ms-terraform-lsp.exe
+    - target: win_arm64
+      file: ms-terraform-lsp_{{version}}_windows_arm64.zip
+      bin: ms-terraform-lsp.exe
+
+bin:
+  ms-terraform-lsp: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: ms_terraform_lsp


### PR DESCRIPTION
### Describe your changes

<!-- Short description of what has been changed and/or added and why -->

Adds the Microsoft Terraform Providers Language Server, which provides completion, hover documentation and schema validation for the `azapi`, `azurerm` and `msgraph` Terraform providers, and for Azure Verified Modules.

Linux targets are plain rather than `_gnu` because these are static Go builds, matching the existing terraform-ls package.

One thing worth flagging, the binary is around 426 MB unpacked, because the Azure resource schemas are embedded in it.

### Issue ticket number and link

<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)

<!-- A link to evidence that the requirement for the package are fulfilled. -->

Approved at nvim-lspconfig: neovim/nvim-lspconfig#4510, merged as `ms_terraform_lsp`
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review

<!-- Refer to the CONTRIBUTING.md for details on testing -->

- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
          diagnostics -->
      Installed on darwin_arm64 and checked the asset templating with `--target=linux_x64` and `--target=win_x64`. All three resolve the expected release asset and unpack a single binary at the archive root. After installing, the server attaches in Neovim alongside terraformls and completes property names inside an `azapi_resource` body.

### Screenshots

<!-- Leave empty if not applicable -->
