### PR TITLE
feat: add spring-javaformat

### DIFF
--- a/packages/spring-javaformat/package.yaml
+++ b/packages/spring-javaformat/package.yaml
@@ -1,0 +1,20 @@
+---
+name: spring-javaformat
+description: A source formatter that applies Spring wrapping and whitespace conventions.
+homepage: https://github.com/spring-io/spring-javaformat
+licenses:
+  - Apache-2.0
+languages:
+  - Java
+categories:
+  - Formatter
+
+source:
+  # renovate:datasource=github-releases
+  id: pkg:generic/spring-io/spring-javaformat@v0.0.48
+  download:
+    files:
+      spring-javaformat-vscode-extension-{{ version | strip_prefix "v" }}.vsix: https://repo1.maven.org/maven2/io/spring/javaformat/spring-javaformat-vscode-extension/{{ version | strip_prefix "v" }}/spring-javaformat-vscode-extension-{{ version | strip_prefix "v" }}.vsix
+
+bin:
+  spring-javaformat: java-jar:extension/runtime/spring-java-format.jar

--- a/packages/spring-javaformat/package.yaml
+++ b/packages/spring-javaformat/package.yaml
@@ -14,7 +14,7 @@ source:
   id: pkg:generic/spring-io/spring-javaformat@v0.0.48
   download:
     files:
-      spring-javaformat-vscode-extension-{{ version | strip_prefix "v" }}.vsix: https://repo1.maven.org/maven2/io/spring/javaformat/spring-javaformat-vscode-extension/{{ version | strip_prefix "v" }}/spring-javaformat-vscode-extension-{{ version | strip_prefix "v" }}.vsix
+      spring-javaformat.vsix: https://repo1.maven.org/maven2/io/spring/javaformat/spring-javaformat-vscode-extension/{{ version | strip_prefix "v" }}/spring-javaformat-vscode-extension-{{ version | strip_prefix "v" }}.vsix
 
 bin:
   spring-javaformat: java-jar:extension/runtime/spring-java-format.jar


### PR DESCRIPTION
### Describe your changes
Adds [Spring JavaFormat](https://github.com/spring-io/spring-javaformat), the formatter used to apply Spring's Java
wrapping and whitespace conventions.

The package downloads the official Spring JavaFormat VS Code extension
from Maven Central and exposes its bundled shaded
`spring-java-format.jar` runtime as the `spring-javaformat` executable.

### Issue ticket number and link
https://github.com/mason-org/mason.nvim/issues/2112

### Evidence on requirement fulfillment (new packages only)
The GitHub repo has (at the time of making this PR) over 900 stars
<img width="1315" height="82" alt="image" src="https://github.com/user-attachments/assets/b01a357e-45db-4ac4-9953-4010c6099128" />

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
