### PR TITLE
Add armls

### DIFF
--- a/packages/armls/package.yaml
+++ b/packages/armls/package.yaml
@@ -1,0 +1,46 @@
+---
+name: armls
+description: A language server for Arm Assembly
+homepage: https://github.com/arm/armls
+licenses:
+  - proprietary
+languages:
+  - Assembly
+categories:
+  - LSP
+
+source:
+  id: pkg:openvsx/arm/armls@0.16.0
+  download:
+    - target: linux_x64_gnu
+      file: arm.armls-{{ version }}@linux-x64.vsix
+      target_platform: linux-x64
+      bin: extension/tools/armls/armls
+
+    - target: linux_arm64_gnu
+      file: arm.armls-{{ version }}@linux-arm64.vsix
+      target_platform: linux-arm64
+      bin: extension/tools/armls/armls
+
+    - target: darwin_x64
+      file: arm.armls-{{ version }}@darwin-x64.vsix
+      target_platform: darwin-x64
+      bin: extension/tools/armls/armls
+
+    - target: darwin_arm64
+      file: arm.armls-{{ version }}@darwin-arm64.vsix
+      target_platform: darwin-arm64
+      bin: extension/tools/armls/armls
+
+    - target: win_x64
+      file: arm.armls-{{ version }}@win32-x64.vsix
+      target_platform: win32-x64
+      bin: extension/tools/armls/armls.exe
+
+    - target: win_arm64
+      file: arm.armls-{{ version }}@win32-arm64.vsix
+      target_platform: win32-arm64
+      bin: extension/tools/armls/armls.exe
+
+bin:
+  armls: "{{source.download.bin}}"


### PR DESCRIPTION
### Describe your changes

Adds ArmLS, Arm's language server for A32 and A64 Arm Assembly.

The package uses the official platform-specific Open VSX releases and exposes
the bundled `armls` executable through Mason.

Supported targets included:

- Linux x64 (GNU)
- Linux arm64 (GNU)
- macOS x64
- macOS arm64
- Windows x64
- Windows arm64

### Issue ticket number and link
None

### Evidence on requirement fulfillment (new packages only)

ArmLS is an official Arm language server and is published by Arm, a reputable company.

[ArmLS GitHub](https://github.com/arm/armls)

[VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=Arm.armls) 

This fulfills requirement 4: the tool is officially provided/recommended by a
reputable company.

Supporting Evidence:

- Nearly 5,000 installs on the [Visual Studio Marketplace](https://marketplace.visualstudio.com/items?itemName=Arm.armls)
- More than 10,000 downloads on [Open VSX](https://open-vsx.org/extension/arm/armls)

### Checklist before requesting a review

- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
  - ArmLS is not yet currently available in nvim-lspconfig main; [a PR is currently open to add it](https://github.com/neovim/nvim-lspconfig/pull/4515).
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      - Tested installation through a local Mason registry using the
        `linux_x64_gnu` target.
      - Verified the Mason `armls` executable link was created successfully.
      - Verified the installed language server starts successfully.
      - Verified ArmLS attaches in Neovim and provides hover documentation,
        semantic highlighting, and diagnostics.

### Screenshots
None