### PR TITLE
feat(package): add cx

### DIFF
--- a/packages/cx/package.yaml
+++ b/packages/cx/package.yaml
@@ -1,0 +1,23 @@
+name: cx
+description: CX — the data and code language. One binary carries the CLI, the language server (cx lsp), and libcx.
+homepage: https://cxhome.org
+licenses:
+  - Apache-2.0
+languages:
+  - CX
+categories:
+  - LSP
+  - Compiler
+
+source:
+  id: pkg:github/cx-home/cx@v0.17.0
+  asset:
+    - target: darwin_arm64
+      file: cx-darwin-arm64.tar.gz
+      bin: cx
+    - target: linux_arm64
+      file: cx-linux-arm64.tar.gz
+      bin: cx
+
+bin:
+  cx: "{{source.asset.bin}}"


### PR DESCRIPTION
Adds **CX** (https://cxhome.org) — the data and code language. One binary carries the CLI, the language server (`cx lsp`), and libcx.

Release assets are flat, stable-named tarballs (`cx-darwin-arm64.tar.gz`, `cx-linux-arm64.tar.gz`) with the `cx` binary at the tar root, published per release at https://github.com/cx-home/cx/releases (current: v0.17.0). Further targets (linux x86_64, windows) join as the release lane ships them.

Verified locally: both assets download and extract, `cx --version` reports the release headline, `cx lsp --stdio` speaks LSP.