### PR TITLE
bump(roslyn-language-server): update to v5.12.0-1.26426.8

### DIFF
--- a/packages/roslyn-language-server/package.yaml
+++ b/packages/roslyn-language-server/package.yaml
@@ -12,7 +12,7 @@ categories:
   - LSP
 
 source:
-  id: pkg:nuget/roslyn-language-server@5.11.0-1.26380.4
+  id: pkg:nuget/roslyn-language-server@5.12.0-1.26426.8
 
 bin:
   roslyn-language-server: nuget:roslyn-language-server


### PR DESCRIPTION
### Describe your changes
Manually bump `roslyn-language-server`'s version to `v5.12.0-1.26426.8` due to `renovate` not detecting new `NuGet` pre-release versions.

### Issue ticket number and link
N/A

### Evidence on requirement fulfillment (new packages only)
N/A

### Checklist before requesting a review
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Screenshots
N/A
