### PR TITLE
feat: add laravel-lsp

### DIFF
--- a/packages/laravel-lsp/package.yaml
+++ b/packages/laravel-lsp/package.yaml
@@ -1,0 +1,30 @@
+---
+name: laravel-lsp
+description: |
+  Laravel LSP provides framework-aware editor features for Laravel applications, including completions, hover
+  information, diagnostics, document links, Go to Definition, and code actions for Laravel and Blade code.
+homepage: https://github.com/laravel/lsp
+licenses:
+  - MIT
+languages:
+  - PHP
+  - Blade
+categories:
+  - LSP
+
+source:
+  id: pkg:github/laravel/lsp@v0.0.31
+  asset:
+    - target: darwin_arm64
+      file: server-{{version}}-arm64-darwin
+    - target: darwin_x64
+      file: server-{{version}}-x64-darwin
+    - target: linux_arm64
+      file: server-{{version}}-arm64-linux
+    - target: linux_x64
+      file: server-{{version}}-x64-linux
+    - target: win_x64
+      file: server-{{version}}-x64-win32.exe
+
+bin:
+  laravel-lsp: "{{source.asset.file}}"


### PR DESCRIPTION
### Describe your changes

Adds the official Laravel LSP (`laravel/lsp`) as `laravel-lsp`. It provides
framework-aware completions, hover information, diagnostics, document links,
go to definition, and code actions for Laravel and Blade code.

The project publishes statically-linked, self-contained standalone server
binaries (built with `static-php-cli`) per release for `darwin_arm64`,
`darwin_x64`, `linux_arm64`, `linux_x64`, and `win_x64` — no system PHP
required. Since the binaries are statically linked, plain `linux_arm64` /
`linux_x64` targets are used rather than `_gnu` variants (following the
`buf` / `symfony-lsp` precedent for statically-linked release assets).

This is a different, unrelated project from the existing `laravel-ls`
package (`laravel-ls/laravel-ls`, a third-party Go implementation).

### Issue ticket number and link

Requested in https://github.com/laravel/lsp/issues/53

### Evidence on requirement fulfillment

`laravel/lsp` is the official Laravel Language Server, published under the
`laravel` GitHub organization (https://github.com/laravel/lsp) — Laravel is
a widely used, reputable PHP framework/company. It also has 282+ stars on
GitHub, clearing the 100-star requirement independently.

### Checklist before requesting a review

- [ ] If the package is available at nvim-lspconfig, I also added the
      respective name to `neovim.lspconfig`.
      — No `nvim-lspconfig` entry exists yet for `laravel-lsp` (only
      `laravel_ls.lua`, for the unrelated `laravel-ls` project), so
      `neovim.lspconfig` is intentionally omitted for now.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

I don't have a local Neovim + mason.nvim setup available in this
environment to drive `:MasonInstall`, so instead I verified the concrete
things a review of this definition would otherwise have to trust:

- Confirmed every `source.asset.file` value (for all 5 targets) resolves to
  a real, existing release asset under
  `github.com/laravel/lsp/releases/download/v0.0.31/` (HTTP 200 for each).
- Downloaded the `darwin_arm64` asset directly (matching this machine) and
  ran it: `server-v0.0.31-arm64-darwin --version` prints `Laravel LSP
  v0.0.31`, matching the pinned version, and `... lsp --help` confirms the
  `lsp` subcommand starts the server — i.e. the exact file this definition
  maps into `bin.laravel-lsp` is a genuinely working executable, not just a
  well-formed URL.
- Validated `package.yaml` parses correctly and cross-checked `target`
  values (`darwin_arm64`, `darwin_x64`, `linux_arm64`, `linux_x64`,
  `win_x64`) and the `LSP` category against the enums in
  `mason-org/registry-schema`.

Happy to have a maintainer (or CI) run the full `:MasonInstall` /
package-tests pass on top of this if that verification isn't considered
sufficient.

### Screenshots

Not applicable.