### PR TITLE
bump(java-test): upgrade to 0.46.0

### DIFF
--- a/packages/java-test/package.yaml
+++ b/packages/java-test/package.yaml
@@ -12,7 +12,7 @@ description: |
   - JUnit 4 (v4.8.0+)
   - JUnit 5 (v5.1.0+)
   - JUnit 6 (v6.0.1+)
-  - TestNG (v6.8.0+)
+  - TestNG (v6.9.13.3+)
 
 homepage: https://github.com/microsoft/vscode-java-test
 licenses:
@@ -23,7 +23,7 @@ categories:
   - DAP
 
 source:
-  id: pkg:openvsx/vscjava/vscode-java-test@0.45.0
+  id: pkg:openvsx/vscjava/vscode-java-test@0.46.0
   download:
     file: vscjava.vscode-java-test-{{version}}.vsix
     plugin_version: 0.43.1


### PR DESCRIPTION
### Describe your changes
<!-- Short description of what has been changed and/or added and why -->
upgrade java-test plugin to the latest version available at https://open-vsx.org/extension/vscjava/vscode-java-test

### Issue ticket number and link
<!-- Leave empty if not available -->

### Evidence on requirement fulfillment (new packages only)
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
Plugin installed : 
<img width="756" height="319" alt="image" src="https://github.com/user-attachments/assets/589c7dc0-cea3-4e15-9be4-ef4ee2931c78" />

Plugin working with nvim-jdtls :
<img width="488" height="125" alt="image" src="https://github.com/user-attachments/assets/86b1668f-8974-4066-95f7-92a58110c26c" />

<!-- Leave empty if not applicable -->
