### PR TITLE
bump(kotlin-lsp): update to kotlin-lsp/v263.4421.0

### DIFF
--- a/packages/kotlin-lsp/package.yaml
+++ b/packages/kotlin-lsp/package.yaml
@@ -12,7 +12,7 @@ categories:
 source:
   # renovate:versioning=regex:^kotlin-lsp/v(?<major>\d+)\.(?<minor>\d+)\.(?<patch>\d+)$
   # renovate:datasource=github-releases
-  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v262.9593.0
+  id: pkg:generic/Kotlin/kotlin-lsp@kotlin-lsp/v263.4421.0
   download:
     - target: darwin_x64
       files:


### PR DESCRIPTION
### Describe your changes
Bumps `kotlin-lsp` to version `v263.4421.0`.

The previous build (`v262.9593.0`) expired around September 7, causing the server to immediately exit with code 7 on launch:
> "This build of intellij-server has expired. The IDE will now close. Please download a new build from https://www.jetbrains.com/intellij-server/"

JetBrains has published the `263.4421.0` standalone binaries and VS Code extension (v0.0.11), but has had a delay creating the release tag on GitHub, which prevented Renovate from opening the bump PR automatically (see [Kotlin/kotlin-lsp#271](https://github.com/Kotlin/kotlin-lsp/issues/271#issuecomment-3263721345)).

All platform binaries for `263.4421.0` are live on the JetBrains CDN:
- `darwin_x64`: `https://download-cdn.jetbrains.com/language-server/kotlin-server/263.4421.0/kotlin-server-263.4421.0.sit`
- `darwin_arm64`: `https://download-cdn.jetbrains.com/language-server/kotlin-server/263.4421.0/kotlin-server-263.4421.0-aarch64.sit`
- `linux_x64`: `https://download-cdn.jetbrains.com/language-server/kotlin-server/263.4421.0/kotlin-server-263.4421.0.tar.gz`
- `linux_arm64`: `https://download-cdn.jetbrains.com/language-server/kotlin-server/263.4421.0/kotlin-server-263.4421.0-aarch64.tar.gz`
- `win_x64`: `https://download-cdn.jetbrains.com/language-server/kotlin-server/263.4421.0/kotlin-server-263.4421.0.win.zip`
- `win_arm64`: `https://download-cdn.jetbrains.com/language-server/kotlin-server/263.4421.0/kotlin-server-263.4421.0-aarch64.win.zip`

### Issue ticket number and link
Ref: https://github.com/Kotlin/kotlin-lsp/issues/271

### Evidence on requirement fulfillment (new packages only)
N/A (update to existing package)

### Checklist before requesting a review
- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.