### PR TITLE
feat(rust-glancer): add package

### DIFF
--- a/packages/rust-glancer/package.yaml
+++ b/packages/rust-glancer/package.yaml
@@ -1,0 +1,37 @@
+---
+name: rust-glancer
+description: |
+  An experimental Rust LSP implementation that is optimized for low memory usage and near-instant editor restarts.
+homepage: https://github.com/rust-glancer/rust-glancer
+licenses:
+  - Apache-2.0
+  - MIT
+languages:
+  - Rust
+categories:
+  - LSP
+
+source:
+  id: pkg:github/rust-glancer/rust-glancer@v0.2.0
+  asset:
+    - target: linux_x64_gnu
+      file: rust-glancer-0.2.0-x86_64-unknown-linux-gnu.tar.gz
+      bin: rust-glancer
+    - target: linux_arm64_gnu
+      file: rust-glancer-0.2.0-aarch64-unknown-linux-gnu.tar.gz
+      bin: rust-glancer
+    - target: darwin_x64
+      file: rust-glancer-0.2.0-x86_64-apple-darwin.tar.gz
+      bin: rust-glancer
+    - target: darwin_arm64
+      file: rust-glancer-0.2.0-aarch64-apple-darwin.tar.gz
+      bin: rust-glancer
+    - target: win_x64
+      file: rust-glancer-0.2.0-x86_64-pc-windows-msvc.tar.gz
+      bin: rust-glancer.exe
+
+bin:
+  rust-glancer: "{{source.asset.bin}}"
+
+neovim:
+  lspconfig: rust_glancer


### PR DESCRIPTION
### Describe your changes

Add [rust-glancer](https://github.com/rust-glancer/rust-glancer) v0.2.0, an experimental Rust language server optimized for low memory usage and near-instant editor restarts.

- Install standalone binaries directly from GitHub release archives.
- Support Linux GNU x64/ARM64, macOS x64/ARM64, and Windows x64.
- Expose the `rust-glancer` executable and register `neovim.lspconfig: rust_glancer`.

### Issue ticket number and link

### Evidence on requirement fulfillment (new packages only)

rust-glancer is included in nvim-lspconfig: https://github.com/neovim/nvim-lspconfig/blob/master/lsp/rust_glancer.lua

### Checklist before requesting a review

- [x] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.

### Validation

- Passed registry JSON Schema validation and formatting checks.
- Successfully installed using Mason with the local filesystem registry on Linux x64.
- Successfully downloaded, extracted, and linked the other four targets using Mason target emulation on Linux.
- Native Linux x64 executable reports `rust-glancer 0.2.0` with `--version`. Full editor/LSP integration has been tested locally.

### Screenshots
