### PR TITLE
Add topiary

### DIFF
--- a/packages/topiary/package.yaml
+++ b/packages/topiary/package.yaml
@@ -1,0 +1,41 @@
+---
+name: topiary
+description: |
+  Topiary is designed for formatter authors and formatter users. Authors can create a formatter for a language without
+  having to write their own formatting engine or even their own parser.
+homepage: https://topiary.tweag.io
+licenses:
+  - MIT
+languages:
+  - Bash
+  - JSON
+  - Nickel
+  - OCaml
+  - OCaml-interface
+  - OCamllex
+  - TOML
+  - Query
+categories:
+  - Formatter
+
+source:
+  id: pkg:github/topiary/topiary@v0.7.3
+  asset:
+    - target: darwin_arm64
+      file: topiary-cli-aarch64-apple-darwin.tar.xz
+      bin: topiary-cli-aarch64-apple-darwin/topiary
+    - target: darwin_x64
+      file: topiary-cli-x86_64-apple-darwin.tar.xz
+      bin: topiary-cli-x86_64-apple-darwin/topiary
+    - target: win_x64
+      file: topiary-cli-x86_64-pc-windows-msvc.zip
+      bin: topiary.exe
+    - target: linux_arm64_gnu
+      file: topiary-cli-aarch64-unknown-linux-gnu.tar.xz
+      bin: topiary-cli-aarch64-unknown-linux-gnu/topiary
+    - target: linux_x64_gnu
+      file: topiary-cli-x86_64-unknown-linux-gnu.tar.xz
+      bin: topiary-cli-x86_64-unknown-linux-gnu/topiary
+
+bin:
+  topiary: '{{source.asset.bin}}'


### PR DESCRIPTION
### Describe your changes
This PR adds [Topiary](https://topiary.tweag.io/), a formatter and a formatter framework. I currently only use it for formatting tree-sitter injection files (query) but it also supports a list of other languages. The current [list](https://topiary.tweag.io/book/reference/language-support.html) is:

- Bash
- JSON
- Nickel
- OCaml
- OCamllex
- TOML
- Tree-sitter queries

Supported targets are:

- Linux x64 (GNU)
- Linux arm64 (GNU)
- macOS (Apple Silicon)
- macOS (Intel)
- Windows x64

### Issue ticket number and link

### Evidence on requirement fulfillment (new packages only)
Topiary has an active [repository](https://github.com/topiary/topiary) and currently has been starred well over 800 times. It's also used by several [other projects](https://topiary.tweag.io/book/reference/language-support.html#topiary-cultivars).
<!-- A link to evidence that the requirement for the package are fulfilled. -->
<!-- see https://github.com/mason-org/mason-registry/blob/main/CONTRIBUTING.md#requirements -->

### Checklist before requesting a review
<!-- Refer to the CONTRIBUTING.md for details on testing -->
- [ ] If the package is available at nvim-lspconfig, I also added the respective name to `neovim.lspconfig`.
- [x] I have successfully tested installation of the package.
- [x] I have successfully tested the package after installation.
      <!-- For example: successfully starting the LSP server inside Neovim, or successfully integrated linting
      diagnostics -->

### Screenshots
<!-- Leave empty if not applicable -->
